### PR TITLE
Mock/user auth api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+POSTGRES_DB=************
+POSTGRES_USER=************
+POSTGRES_PASSWORD=************
+
+NODE_ENV=************
+SOCKET_PORT=************
+NEXT_PUBLIC_SOCKET_URL=*************
+NEXT_PUBLIC_API_URL=************
+JWT_SECRET=************

--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@ POSTGRES_DB=************
 POSTGRES_USER=************
 POSTGRES_PASSWORD=************
 
-NODE_ENV=************
-SOCKET_PORT=************
-NEXT_PUBLIC_SOCKET_URL=*************
-NEXT_PUBLIC_API_URL=************
-JWT_SECRET=************
+NODE_ENV=**********
+NEXT_PUBLIC_SOCKET_PORT=****
+NEXT_PUBLIC_SOCKET_URL=*********************
+NEXT_PUBLIC_API_URL=*********************
+JWT_SECRET=***********************

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.validate.enable": false
+}

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ POSTGRES_USER=*****
 POSTGRES_PASSWORD=******
 
 NODE_ENV=******
-SOCKET_PORT=*****
-
-NEXT_PUBLIC_SOCKET_URL=******
+NEXT_PUBLIC_SOCKET_PORT=*****
+NEXT_PUBLIC_SOCKET_URL=*********
+NEXT_PUBLIC_API_URL=*************
+JWT_SECRET=******
 ```
 
 ### Running the project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - "${NEXT_PUBLIC_SOCKET_PORT}:${NEXT_PUBLIC_SOCKET_PORT}"
     environment:
       - NODE_ENV=${NODE_ENV}
-      - PORT=${NEXSOCKET_PORT}
+      - PORT=${NEXT_PUBLIC_SOCKET_PORT}
     volumes:
       - ./socket_server:/app
       - /app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - private-network
     restart: unless-stopped
 
-  # Socket.io game server
+  # Socket.io
   socket-server:
     build:
       context: ./socket_server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,10 @@ services:
       context: ./socket_server
       dockerfile: Dockerfile
     ports:
-      - "${SOCKET_PORT}:${SOCKET_PORT}"
+      - "${NEXT_PUBLIC_SOCKET_PORT}:${NEXT_PUBLIC_SOCKET_PORT}"
     environment:
       - NODE_ENV=${NODE_ENV}
-      - PORT=${SOCKET_PORT}
+      - PORT=${NEXSOCKET_PORT}
     volumes:
       - ./socket_server:/app
       - /app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - private-network
     restart: unless-stopped
 
-  # Socket.io
+  # Socket.io game server
   socket-server:
     build:
       context: ./socket_server
@@ -31,8 +31,26 @@ services:
     networks:
       - game-network
     restart: unless-stopped
- 
-  #Frontend
+
+  # Mock REST API (Hono) — replace internals with real DB later
+  mock-server:
+    build:
+      context: ./mock_server
+      dockerfile: Dockerfile
+    ports:
+      - "${API_PORT:-4000}:4000"
+    environment:
+      - NODE_ENV=${NODE_ENV}
+      - PORT=4000
+      - JWT_SECRET=${JWT_SECRET:-mock-super-secret-dev-key}
+    volumes:
+      - ./mock_server:/app
+      - /app/node_modules
+    networks:
+      - game-network
+    restart: unless-stopped
+
+  # Frontend (Next.js)
   frontend:
     build:
       context: ./frontend
@@ -41,6 +59,7 @@ services:
       - "3000:3000"
     environment:
       - NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL}
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:4000}
     volumes:
       - ./frontend:/app
       - /app/node_modules
@@ -48,8 +67,9 @@ services:
       - game-network
     depends_on:
       - socket-server
+      - mock-server
     restart: unless-stopped
- 
+
 networks:
   game-network:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     environment:
       - NODE_ENV=${NODE_ENV}
       - PORT=4000
-      - JWT_SECRET=${JWT_SECRET:-mock-super-secret-dev-key}
+      - JWT_SECRET=${JWT_SECRET}
     volumes:
       - ./mock_server:/app
       - /app/node_modules

--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { clearToken, getToken } from "@/lib/api";
 
 const navLinks = [
   { href: "/login", label: "Login" },
   { href: "/signup", label: "Sign up" },
 ];
 
-// TODO: Add user state and conditionally show profile/logout links when logged in, and login/signup when logged out.
+// TODO: add pop up to ask if you want to sign up if login fail. 
 
 function isActive(pathname: string, href: string) {
   if (href === "/") {
@@ -20,6 +22,28 @@ function isActive(pathname: string, href: string) {
 
 export function Header() {
   const pathname = usePathname();
+  const router = useRouter();
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const syncAuthState = () => {
+      setIsLoggedIn(Boolean(getToken()));
+    };
+
+    syncAuthState();
+    window.addEventListener("auth-changed", syncAuthState);
+
+    return () => {
+      window.removeEventListener("auth-changed", syncAuthState);
+    };
+  }, []);
+
+  const handleLogout = () => {
+    clearToken();
+    setIsLoggedIn(false);
+    router.push("/");
+    router.refresh();
+  };
 
   return (
     <header className="sticky top-0 z-50 border-b border-neutral-800 bg-neutral-950/90 backdrop-blur">
@@ -29,24 +53,34 @@ export function Header() {
         </Link>
 
         <nav className="flex items-center gap-2 sm:gap-3">
-          {navLinks.map((link) => {
-            const active = isActive(pathname, link.href);
+          {isLoggedIn ? (
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="rounded-md px-3 py-2 text-sm font-medium text-neutral-300 transition-colors hover:bg-neutral-900 hover:text-white"
+            >
+              Log out
+            </button>
+          ) : (
+            navLinks.map((link) => {
+              const active = isActive(pathname, link.href);
 
-            return (
-              <Link
-                key={link.href}
-                href={link.href}
-                className={[
-                  "rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                  active
-                    ? "bg-neutral-800 text-white"
-                    : "text-neutral-300 hover:bg-neutral-900 hover:text-white",
-                ].join(" ")}
-              >
-                {link.label}
-              </Link>
-            );
-          })}
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={[
+                    "rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    active
+                      ? "bg-neutral-800 text-white"
+                      : "text-neutral-300 hover:bg-neutral-900 hover:text-white",
+                  ].join(" ")}
+                >
+                  {link.label}
+                </Link>
+              );
+            })
+          )}
         </nav>
       </div>
     </header>

--- a/frontend/app/game/multiplayer/page.tsx
+++ b/frontend/app/game/multiplayer/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { Canvas } from "@react-three/fiber";
 
@@ -40,7 +41,15 @@ export default function GamePage() {
   return (
     <main className="min-h-screen bg-neutral-950 text-neutral-100">
       <section className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4">
-        <h1 className="text-2xl font-semibold">Multiplayer Prototype</h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">Multiplayer Prototype</h1>
+          <Link
+            href="/lobby"
+            className="rounded-md border border-neutral-700 px-3 py-1.5 text-xs font-medium text-neutral-200 transition hover:bg-neutral-900"
+          >
+            Back to Lobby
+          </Link>
+        </div>
 
         <GameLobbyControls
           name={name}

--- a/frontend/app/game/solo/page.tsx
+++ b/frontend/app/game/solo/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import * as THREE from "three";
@@ -36,11 +37,19 @@ export default function SoloPage() {
 		<main className="min-h-screen bg-neutral-950 text-neutral-100">
 			<section className="mx-auto flex max-w-6xl flex-col gap-3 px-4 py-4">
 				<div className="flex items-center justify-between">
-					<h1 className="text-xl font-semibold tracking-tight">solo dev mode</h1>
-					<span className="flex items-center gap-2 text-sm text-neutral-400">
-						<span className={`inline-block h-2 w-2 rounded-full ${connected ? "bg-green-500" : "bg-red-500"}`} />
-						{connected ? "connected" : "disconnected"}
-					</span>
+					<div className="flex items-center gap-3">
+						<h1 className="text-xl font-semibold tracking-tight">solo dev mode</h1>
+						<span className="flex items-center gap-2 text-sm text-neutral-400">
+							<span className={`inline-block h-2 w-2 rounded-full ${connected ? "bg-green-500" : "bg-red-500"}`} />
+							{connected ? "connected" : "disconnected"}
+						</span>
+					</div>
+					<Link
+						href="/lobby"
+						className="rounded-md border border-neutral-700 px-3 py-1.5 text-xs font-medium text-neutral-200 transition hover:bg-neutral-900"
+					>
+						Back to Lobby
+					</Link>
 				</div>
 
 				{!joinedRoomId ? (

--- a/frontend/app/game/solo/page.tsx
+++ b/frontend/app/game/solo/page.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { useState } from "react";
 import { Canvas } from "@react-three/fiber";
-import * as THREE from "three";
 
 import { WorldScene } from "../components/WorldScene";
 import { useGameSession } from "../hooks/useGameSession";

--- a/frontend/app/lobby/page.tsx
+++ b/frontend/app/lobby/page.tsx
@@ -1,12 +1,10 @@
+"use client";
+
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 import { FriendsSidebar } from "@/app/lobby/components/FriendsSidebar";
-
-const mockProfile = {
-  displayName: "Player One",
-  rankLabel: "Rookie Wrestler",
-  avatarInitials: "PO",
-};
+import { apiGetMe, apiGetMyStats, type User, type UserStats } from "@/lib/api";
 
 const roomLinks = [
   {
@@ -41,7 +39,46 @@ const roomLinks = [
   },
 ];
 
+function getRankLabel(rating: number | undefined) {
+  if (rating === undefined) return "Rookie Wrestler";
+  if (rating >= 1800) return "Yokozuna";
+  if (rating >= 1500) return "Ozeki";
+  if (rating >= 1200) return "Sekiwake";
+  return "Rookie Wrestler";
+}
+
 export default function LobbyPage() {
+  const [user, setUser] = useState<User | null>(null);
+  const [stats, setStats] = useState<UserStats | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadLobbyProfile = async () => {
+      try {
+        const [meResponse, statsResponse] = await Promise.all([apiGetMe(), apiGetMyStats()]);
+        if (cancelled) return;
+        setUser(meResponse.user);
+        setStats(statsResponse.stats);
+      } catch {
+        if (cancelled) return;
+        setUser(null);
+        setStats(null);
+      }
+    };
+
+    loadLobbyProfile();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const avatarInitials = user?.nickname ? user.nickname.slice(0, 2).toUpperCase() : "PO";
+
+  const displayName = user?.nickname ?? "Player One";
+  const rankLabel = getRankLabel(stats?.rating);
+
   return (
     <main className="min-h-screen bg-neutral-950 px-4 py-6 text-neutral-100 sm:px-6 lg:px-8">
       <section className="mx-auto flex min-h-[calc(100vh-6.5rem)] w-full max-w-6xl flex-col gap-4">
@@ -84,12 +121,25 @@ export default function LobbyPage() {
 
             <div className="flex flex-1 items-start justify-center py-6 md:items-center md:py-8">
               <div className="w-full max-w-xs rounded-[2rem] border border-neutral-700/80 bg-neutral-950/80 p-6 text-center shadow-2xl shadow-black/40 backdrop-blur-md sm:max-w-sm sm:p-8">
-                <div className="mx-auto flex h-28 w-28 items-center justify-center rounded-full border-4 border-neutral-700 bg-gradient-to-br from-neutral-700 via-neutral-800 to-neutral-900 text-4xl font-semibold tracking-wide text-white shadow-lg shadow-black/30 sm:h-32 sm:w-32">
-                  {mockProfile.avatarInitials}
-                </div>
+                {user?.avatar_url ? (
+                  <img
+                    src={user.avatar_url}
+                    alt={`${displayName} avatar`}
+                    className="mx-auto h-28 w-28 rounded-full border-4 border-neutral-700 bg-neutral-900 object-cover shadow-lg shadow-black/30 sm:h-32 sm:w-32"
+                  />
+                ) : (
+                  <div className="mx-auto flex h-28 w-28 items-center justify-center rounded-full border-4 border-neutral-700 bg-gradient-to-br from-neutral-700 via-neutral-800 to-neutral-900 text-4xl font-semibold tracking-wide text-white shadow-lg shadow-black/30 sm:h-32 sm:w-32">
+                    {avatarInitials}
+                  </div>
+                )}
                 <p className="mt-6 text-sm uppercase tracking-[0.3em] text-neutral-500">Current avatar</p>
-                <h2 className="mt-3 text-2xl font-semibold tracking-tight">{mockProfile.displayName}</h2>
-                <p className="mt-2 text-sm text-neutral-400">{mockProfile.rankLabel}</p>
+                <h2 className="mt-3 text-2xl font-semibold tracking-tight">{displayName}</h2>
+                <p className="mt-2 text-sm text-neutral-400">{rankLabel}</p>
+                {stats ? (
+                  <p className="mt-2 text-xs text-neutral-500">
+                    Wins {stats.wins} • Losses {stats.losses} • Rating {stats.rating}
+                  </p>
+                ) : null}
 
                 {/* TODO: Connect this button to the future profile editor or avatar customization flow. */}
                 <Link

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -2,19 +2,31 @@
 
 import { AuthCard } from "@/app/components/AuthCard";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
+import { apiLogin, saveToken } from "@/lib/api";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [statusMessage, setStatusMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setLoading(true);
+    setStatusMessage("");
 
-    setStatusMessage("Login is not connected yet.");
-
-    // TODO: Replace this placeholder with the real login API request.
+    try {
+      const { access_token } = await apiLogin(email, password);
+      saveToken(access_token);
+      router.push("/lobby");
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Login failed");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -63,9 +75,10 @@ export default function LoginPage() {
 
             <button
               type="submit"
-              className="w-full rounded-lg bg-blue-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-blue-500"
+              disabled={loading}
+              className="w-full rounded-lg bg-blue-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:opacity-50"
             >
-              Sign in
+              {loading ? "Signing in…" : "Sign in"}
             </button>
           </form>
 

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -1,24 +1,147 @@
+"use client";
+
 import Link from "next/link";
+import { useEffect, useState } from "react";
+import { apiGetMe, apiGetMyStats, type User, type UserStats } from "@/lib/api";
 
 export default function ProfilePage() {
+  const [user, setUser] = useState<User | null>(null);
+  const [stats, setStats] = useState<UserStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [avatarFailed, setAvatarFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadProfile = async () => {
+      try {
+        setLoading(true);
+        setError("");
+
+        const [meResponse, statsResponse] = await Promise.all([apiGetMe(), apiGetMyStats()]);
+
+        if (cancelled) {
+          return;
+        }
+
+        setUser(meResponse.user);
+        setStats(statsResponse.stats);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load profile data");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadProfile();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <main className="min-h-screen bg-neutral-950 px-4 py-6 text-neutral-100 sm:px-6 lg:px-8">
-          <p className="text-sm uppercase tracking-[0.3em] text-neutral-500">Profile</p>
-          <h1 className="mt-3 text-3xl font-semibold tracking-tight">Profile Placeholder</h1>
-          <p className="mt-4 text-neutral-300">
-            This is a temporary profile page. We can connect avatar updates and user data to the backend later.
-          </p>
+      <section className="mx-auto w-full max-w-3xl rounded-2xl border border-neutral-800 bg-neutral-900/90 p-6 sm:p-8">
+        <p className="text-sm uppercase tracking-[0.3em] text-neutral-500">Profile</p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight">Your Account Data</h1>
+        <p className="mt-3 text-sm text-neutral-400">Values shown below come directly from your mock API.</p>
 
-          {/* TODO: Replace mock content with backend-powered profile details and edit actions. */}
+        {loading ? <p className="mt-6 text-neutral-300">Loading profile...</p> : null}
+        {error ? <p className="mt-6 text-sm text-red-400">{error}</p> : null}
 
-          <div className="mt-8 flex items-center justify-center gap-3">
-            <Link
-              href="/lobby"
-              className="rounded-md bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-500"
-            >
-              Back to Lobby
-            </Link>
+        {!loading && !error && user ? (
+          <div className="mt-8 space-y-8">
+            <div>
+              <h2 className="text-lg font-semibold text-neutral-100">User</h2>
+              <div className="mt-3 flex items-center gap-4 rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+                {user.avatar_url && !avatarFailed ? (
+                  <img
+                    src={user.avatar_url}
+                    alt={`${user.nickname} avatar`}
+                    className="h-16 w-16 rounded-full border border-neutral-700 bg-neutral-900 object-cover"
+                    onError={() => setAvatarFailed(true)}
+                  />
+                ) : (
+                  <div className="flex h-16 w-16 items-center justify-center rounded-full border border-neutral-700 bg-neutral-900 text-xl font-semibold text-neutral-300">
+                    {user.nickname.slice(0, 1).toUpperCase()}
+                  </div>
+                )}
+
+                <div>
+                  <p className="text-sm text-neutral-400">Avatar preview</p>
+                  <p className="text-sm text-neutral-200">
+                    {user.avatar_url && !avatarFailed ? "Loaded from avatar_url" : "Using fallback avatar"}
+                  </p>
+                </div>
+              </div>
+
+              <dl className="mt-3 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+                <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+                  <dt className="text-neutral-400">id</dt>
+                  <dd className="mt-1 break-all text-neutral-100">{user.id}</dd>
+                </div>
+                <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+                  <dt className="text-neutral-400">email</dt>
+                  <dd className="mt-1 break-all text-neutral-100">{user.email}</dd>
+                </div>
+                <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+                  <dt className="text-neutral-400">nickname</dt>
+                  <dd className="mt-1 text-neutral-100">{user.nickname}</dd>
+                </div>
+                <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+                  <dt className="text-neutral-400">avatar_url</dt>
+                  <dd className="mt-1 break-all text-neutral-100">{user.avatar_url ?? "null"}</dd>
+                </div>
+                <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+                  <dt className="text-neutral-400">created_at</dt>
+                  <dd className="mt-1 text-neutral-100">{user.created_at}</dd>
+                </div>
+                <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+                  <dt className="text-neutral-400">updated_at</dt>
+                  <dd className="mt-1 text-neutral-100">{user.updated_at}</dd>
+                </div>
+              </dl>
+            </div>
+
+            <div>
+              <h2 className="text-lg font-semibold text-neutral-100">Stats</h2>
+              <dl className="mt-3 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+                <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+                  <dt className="text-neutral-400">user_id</dt>
+                  <dd className="mt-1 break-all text-neutral-100">{stats?.user_id ?? "-"}</dd>
+                </div>
+                <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+                  <dt className="text-neutral-400">wins</dt>
+                  <dd className="mt-1 text-neutral-100">{stats?.wins ?? 0}</dd>
+                </div>
+                <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+                  <dt className="text-neutral-400">losses</dt>
+                  <dd className="mt-1 text-neutral-100">{stats?.losses ?? 0}</dd>
+                </div>
+                <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+                  <dt className="text-neutral-400">rating</dt>
+                  <dd className="mt-1 text-neutral-100">{stats?.rating ?? 0}</dd>
+                </div>
+              </dl>
+            </div>
           </div>
+        ) : null}
+
+        <div className="mt-8 flex items-center justify-center gap-3">
+          <Link
+            href="/lobby"
+            className="rounded-md bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-500"
+          >
+            Back to Lobby
+          </Link>
+        </div>
+      </section>
     </main>
   );
 }

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
+import { apiSignup, saveToken } from "@/lib/api";
 
 export default function SignupPage() {
   const [displayName, setDisplayName] = useState("");
@@ -9,18 +11,28 @@ export default function SignupPage() {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [statusMessage, setStatusMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-
-    // TODO: Replace this placeholder with the real signup API request.
     event.preventDefault();
+    setStatusMessage("");
+
     if (password !== confirmPassword) {
       setStatusMessage("Passwords do not match.");
       return;
     }
 
-    setStatusMessage("Signup is not connected yet.");
-
+    setLoading(true);
+    try {
+      const { access_token } = await apiSignup(email, displayName, password);
+      saveToken(access_token);
+      router.push("/lobby");
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Signup failed");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -42,7 +54,7 @@ export default function SignupPage() {
                 type="text"
                 value={displayName}
                 onChange={(event) => setDisplayName(event.target.value)}
-                placeholder="PlayerOne"
+                placeholder="Display Name"
                 className="w-full rounded-lg border border-neutral-700 bg-neutral-950 px-4 py-3 text-sm outline-none transition focus:border-orange-500"
                 required
               />
@@ -86,9 +98,10 @@ export default function SignupPage() {
 
             <button
               type="submit"
-              className="w-full rounded-lg bg-orange-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-orange-500"
+              disabled={loading}
+              className="w-full rounded-lg bg-orange-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-orange-500 disabled:opacity-50"
             >
-              Sign up
+              {loading ? "Creating account…" : "Sign up"}
             </button>
           </form>
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -76,7 +76,8 @@ async function apiFetch<T>(
     headers["Authorization"] = `Bearer ${token}`;
   }
 
-  const res = await fetch(`${API_BASE}${path}`, { ...options, headers });
+  const url = new URL(path, API_BASE);
+  const res = await fetch(url.toString(), { ...options, headers });
   const data = await res.json();
 
   if (!res.ok) {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,117 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+
+// ── Types (mirrors the mock store / schema) ────────────────────────────────
+
+export type User = {
+  id: string;
+  email: string;
+  nickname: string;
+  avatar_url: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type UserStats = {
+  user_id: string;
+  wins: number;
+  losses: number;
+  rating: number;
+};
+
+export type AuthResponse = {
+  access_token: string;
+  user: User;
+};
+
+export type ApiError = {
+  error: string;
+};
+
+// ── Token helpers (localStorage) ──────────────────────────────────────────
+
+const TOKEN_KEY = "access_token";
+const AUTH_CHANGED_EVENT = "auth-changed";
+
+export function saveToken(token: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  localStorage.setItem(TOKEN_KEY, token);
+  document.cookie = `${TOKEN_KEY}=${encodeURIComponent(token)}; path=/; max-age=604800; samesite=lax`;
+  window.dispatchEvent(new Event(AUTH_CHANGED_EVENT));
+}
+
+export function getToken(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function clearToken() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  localStorage.removeItem(TOKEN_KEY);
+  document.cookie = `${TOKEN_KEY}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=lax`;
+  window.dispatchEvent(new Event(AUTH_CHANGED_EVENT));
+}
+
+// ── Low-level fetch wrapper ────────────────────────────────────────────────
+
+async function apiFetch<T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options.headers as Record<string, string>),
+  };
+
+  const token = getToken();
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${API_BASE}${path}`, { ...options, headers });
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw new Error((data as ApiError).error ?? "Unknown API error");
+  }
+
+  return data as T;
+}
+
+// ── Auth endpoints ─────────────────────────────────────────────────────────
+
+export async function apiLogin(email: string, password: string): Promise<AuthResponse> {
+  return apiFetch<AuthResponse>("/auth/login", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+}
+
+export async function apiSignup(
+  email: string,
+  nickname: string,
+  password: string,
+): Promise<AuthResponse> {
+  return apiFetch<AuthResponse>("/auth/signup", {
+    method: "POST",
+    body: JSON.stringify({ email, nickname, password }),
+  });
+}
+
+// ── User endpoints (require token) ────────────────────────────────────────
+
+export async function apiGetMe(): Promise<{ user: User }> {
+  return apiFetch<{ user: User }>("/users/me");
+}
+
+export async function apiGetMyStats(): Promise<{ stats: UserStats }> {
+  return apiFetch<{ stats: UserStats }>("/users/me/stats");
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -25,6 +25,6 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)",
+    "/((?!_next/|favicon.ico|robots.txt|sitemap.xml).*)",
   ],
 };

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 const TOKEN_COOKIE_KEY = "access_token";
 
-const PUBLIC_PATHS = new Set(["/", "/login", "/signup"]);
+const PUBLIC_PATHS = new Set(["/", "/login", "/signup", "/terms", "/privacy"]);
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const TOKEN_COOKIE_KEY = "access_token";
+
+const PUBLIC_PATHS = new Set(["/", "/login", "/signup"]);
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (PUBLIC_PATHS.has(pathname)) {
+    return NextResponse.next();
+  }
+
+  const token = request.cookies.get(TOKEN_COOKIE_KEY)?.value;
+
+  if (!token) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = "/";
+    redirectUrl.search = "";
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)",
+  ],
+};

--- a/mock_server/.dockerignore
+++ b/mock_server/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.git
+.gitignore
+.DS_Store
+.env
+.env.*

--- a/mock_server/Dockerfile
+++ b/mock_server/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 4000
+
+CMD ["node", "--watch", "index.js"]

--- a/mock_server/Dockerfile
+++ b/mock_server/Dockerfile
@@ -2,8 +2,8 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && pnpm install --frozen-lockfile
 
 COPY . .
 

--- a/mock_server/config.js
+++ b/mock_server/config.js
@@ -1,0 +1,6 @@
+export const PORT = process.env.PORT ? Number(process.env.PORT) : 4000;
+
+// Swap this out for a real secret loaded from env in production
+export const JWT_SECRET = process.env.JWT_SECRET ?? "mock-super-secret-dev-key";
+
+export const JWT_EXPIRES_IN = "7d";

--- a/mock_server/config.js
+++ b/mock_server/config.js
@@ -1,6 +1,6 @@
 export const PORT = process.env.PORT ? Number(process.env.PORT) : 4000;
 
 // Swap this out for a real secret loaded from env in production
-export const JWT_SECRET = process.env.JWT_SECRET ?? "mock-super-secret-dev-key";
+export const JWT_SECRET = process.env.JWT_SECRET || "mock-super-secret-dev-key";
 
 export const JWT_EXPIRES_IN = "7d";

--- a/mock_server/index.js
+++ b/mock_server/index.js
@@ -24,7 +24,7 @@ app.use(
 app.get("/health", (c) => c.json({ status: "ok", server: "mock-server" }));
 app.route("/auth", authRoutes);
 
-// ── JWT auth middleware (all routes below this line are protected) ──────────
+// ── JWT auth middleware (all /users routes are protected) ───────────────────
 app.use("/users/*", async (c, next) => {
   const authHeader = c.req.header("Authorization");
 

--- a/mock_server/index.js
+++ b/mock_server/index.js
@@ -1,0 +1,52 @@
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { logger } from "hono/logger";
+import { serve } from "@hono/node-server";
+import jwt from "jsonwebtoken";
+import { PORT, JWT_SECRET } from "./config.js";
+import { authRoutes } from "./routes/auth.js";
+import { userRoutes } from "./routes/users.js";
+
+const app = new Hono();
+
+// ── Global middleware ──────────────────────────────────────────────────────
+app.use("*", logger());
+app.use(
+  "*",
+  cors({
+    origin: "*", // tighten this when you have real origins
+    allowHeaders: ["Content-Type", "Authorization"],
+    allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+  }),
+);
+
+// ── Public routes ──────────────────────────────────────────────────────────
+app.get("/health", (c) => c.json({ status: "ok", server: "mock-server" }));
+app.route("/auth", authRoutes);
+
+// ── JWT auth middleware (all routes below this line are protected) ──────────
+app.use("/users/*", async (c, next) => {
+  const authHeader = c.req.header("Authorization");
+
+  if (!authHeader?.startsWith("Bearer ")) {
+    return c.json({ error: "Missing or malformed Authorization header" }, 401);
+  }
+
+  const token = authHeader.slice(7);
+
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+    c.set("userId", payload.sub);
+    await next();
+  } catch {
+    return c.json({ error: "Invalid or expired token" }, 401);
+  }
+});
+
+// ── Protected routes ───────────────────────────────────────────────────────
+app.route("/users", userRoutes);
+
+// ── Start ──────────────────────────────────────────────────────────────────
+serve({ fetch: app.fetch, port: PORT }, () => {
+  console.log(`API server running on :${PORT}`);
+});

--- a/mock_server/index.js
+++ b/mock_server/index.js
@@ -36,6 +36,10 @@ app.use("/users/*", async (c, next) => {
 
   try {
     const payload = jwt.verify(token, JWT_SECRET);
+
+    if (!payload || typeof payload !== "object" || typeof payload.sub !== "string") {
+      return c.json({ error: "Invalid or expired token" }, 401);
+    }
     c.set("userId", payload.sub);
     await next();
   } catch {

--- a/mock_server/mock/store.js
+++ b/mock_server/mock/store.js
@@ -1,0 +1,98 @@
+import bcrypt from "bcryptjs";
+import { randomUUID } from "crypto";
+
+// ---------------------------------------------------------------------------
+// In-memory store — mirrors the `users` and `user_stats` schema tables.
+// Replace this module with real DB calls when the backend is ready.
+// ---------------------------------------------------------------------------
+
+const SALT_ROUNDS = 10;
+
+// Seed two players so you can always log in without signing up first.
+const users = new Map([
+  [
+    "a1b2c3d4-0001-0000-0000-000000000001",
+    {
+      id: "a1b2c3d4-0001-0000-0000-000000000001",
+      email: "player1@example.com",
+      // bcrypt hash of "password1"
+      password_hash: bcrypt.hashSync("password1", SALT_ROUNDS),
+      nickname: "sumo_king",
+      avatar_url: "https://api.dicebear.com/9.x/shapes/svg?seed=sumo_king",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+  ],
+  [
+    "a1b2c3d4-0002-0000-0000-000000000002",
+    {
+      id: "a1b2c3d4-0002-0000-0000-000000000002",
+      email: "player2@example.com",
+      password_hash: bcrypt.hashSync("password2", SALT_ROUNDS),
+      nickname: "yokozuna42",
+      avatar_url: "https://api.dicebear.com/9.x/shapes/svg?seed=yokozuna42",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+  ],
+]);
+
+// Mirrors `user_stats` table
+const userStats = new Map([
+  ["a1b2c3d4-0001-0000-0000-000000000001", { wins: 10, losses: 3, rating: 1200 }],
+  ["a1b2c3d4-0002-0000-0000-000000000002", { wins: 5,  losses: 7, rating: 950  }],
+]);
+
+// Returns a safe public user object (no password_hash)
+function publicUser(user) {
+  const { password_hash: _, ...safe } = user;
+  return safe;
+}
+
+export const store = {
+  findByEmail(email) {
+    return [...users.values()].find((u) => u.email === email) ?? null;
+  },
+
+  findById(id) {
+    return users.get(id) ?? null;
+  },
+
+  emailTaken(email) {
+    return [...users.values()].some((u) => u.email === email);
+  },
+
+  nicknameTaken(nickname) {
+    return [...users.values()].some((u) => u.nickname === nickname);
+  },
+
+  async createUser({ email, nickname, password }) {
+    const id = randomUUID();
+    const password_hash = await bcrypt.hash(password, SALT_ROUNDS);
+    const now = new Date().toISOString();
+    const user = {
+      id,
+      email,
+      password_hash,
+      nickname,
+      avatar_url: `https://api.dicebear.com/9.x/shapes/svg?seed=${encodeURIComponent(nickname)}`,
+      created_at: now,
+      updated_at: now,
+    };
+    users.set(id, user);
+    userStats.set(id, { wins: 0, losses: 0, rating: 1000 });
+    return publicUser(user);
+  },
+
+  async verifyPassword(user, plainPassword) {
+    return bcrypt.compare(plainPassword, user.password_hash);
+  },
+
+  getPublicUser(user) {
+    return publicUser(user);
+  },
+
+  getStats(userId) {
+    return userStats.get(userId) ?? null;
+  },
+};

--- a/mock_server/package.json
+++ b/mock_server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mock-server",
+  "version": "1.0.0",
+  "description": "Mock REST API for auth — built with Hono, swap internals for real DB later",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "node --watch index.js"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.12.0",
+    "bcryptjs": "^2.4.3",
+    "hono": "^4.4.0",
+    "jsonwebtoken": "^9.0.2"
+  }
+}

--- a/mock_server/pnpm-lock.yaml
+++ b/mock_server/pnpm-lock.yaml
@@ -1,0 +1,145 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.12.0
+        version: 1.19.11(hono@4.12.9)
+      bcryptjs:
+        specifier: ^2.4.3
+        version: 2.4.3
+      hono:
+        specifier: ^4.4.0
+        version: 4.12.9
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.3
+
+packages:
+
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  bcryptjs@2.4.3:
+    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  hono@4.12.9:
+    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
+    engines: {node: '>=16.9.0'}
+
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+snapshots:
+
+  '@hono/node-server@1.19.11(hono@4.12.9)':
+    dependencies:
+      hono: 4.12.9
+
+  bcryptjs@2.4.3: {}
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  hono@4.12.9: {}
+
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
+  lodash.once@4.1.1: {}
+
+  ms@2.1.3: {}
+
+  safe-buffer@5.2.1: {}
+
+  semver@7.7.4: {}

--- a/mock_server/routes/auth.js
+++ b/mock_server/routes/auth.js
@@ -1,0 +1,62 @@
+import { Hono } from "hono";
+import jwt from "jsonwebtoken";
+import { store } from "../mock/store.js";
+import { JWT_SECRET, JWT_EXPIRES_IN } from "../config.js";
+
+export const authRoutes = new Hono();
+
+function signToken(userId) {
+  return jwt.sign({ sub: userId }, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
+}
+
+// POST /auth/signup
+authRoutes.post("/signup", async (c) => {
+  const body = await c.req.json().catch(() => null);
+
+  if (!body?.email || !body?.nickname || !body?.password) {
+    return c.json({ error: "email, nickname, and password are required" }, 400);
+  }
+
+  const { email, nickname, password } = body;
+
+  if (password.length < 6) {
+    return c.json({ error: "Password must be at least 6 characters" }, 400);
+  }
+
+  if (store.emailTaken(email)) {
+    return c.json({ error: "Email already in use" }, 409);
+  }
+
+  if (store.nicknameTaken(nickname)) {
+    return c.json({ error: "Nickname already taken" }, 409);
+  }
+
+  const user = await store.createUser({ email, nickname, password });
+  const access_token = signToken(user.id);
+
+  return c.json({ access_token, user }, 201);
+});
+
+// POST /auth/login
+authRoutes.post("/login", async (c) => {
+  const body = await c.req.json().catch(() => null);
+
+  if (!body?.email || !body?.password) {
+    return c.json({ error: "email and password are required" }, 400);
+  }
+
+  const user = store.findByEmail(body.email);
+
+  if (!user) {
+    return c.json({ error: "Invalid credentials" }, 401);
+  }
+
+  const valid = await store.verifyPassword(user, body.password);
+
+  if (!valid) {
+    return c.json({ error: "Invalid credentials" }, 401);
+  }
+
+  const access_token = signToken(user.id);
+  return c.json({ access_token, user: store.getPublicUser(user) });
+});

--- a/mock_server/routes/users.js
+++ b/mock_server/routes/users.js
@@ -1,0 +1,29 @@
+import { Hono } from "hono";
+import { store } from "../mock/store.js";
+
+export const userRoutes = new Hono();
+
+// GET /users/me  — requires auth middleware applied at the app level
+userRoutes.get("/me", (c) => {
+  // c.get("userId") is set by the auth middleware in index.js
+  const userId = c.get("userId");
+  const user = store.findById(userId);
+
+  if (!user) {
+    return c.json({ error: "User not found" }, 404);
+  }
+
+  return c.json({ user: store.getPublicUser(user) });
+});
+
+// GET /users/me/stats
+userRoutes.get("/me/stats", (c) => {
+  const userId = c.get("userId");
+  const stats = store.getStats(userId);
+
+  if (!stats) {
+    return c.json({ error: "Stats not found" }, 404);
+  }
+
+  return c.json({ stats: { user_id: userId, ...stats } });
+});


### PR DESCRIPTION
* this adds a simple mock api for user auth  so i can start working on re-connections when users get disconnected.
* all it does it give you a access token in your cookies. 
* also added some user UI changes to indicate the user has logged in. 
* added protected urls so you can access anything as long you arn't logged in. 
* showing some data on the profile page. 
* you can log in using an exiting user 
 *email :player1@example.com
 *password:password1
you can find them in /mock_server/mock/store
* will need to add 
JWT_SECRET to your .env file. 


* ユーザー認証用の簡易なモックAPIを追加しました。これにより、ユーザーが切断された際の再接続処理の開発に着手できるようになります。
* これを行うと、Cookieにアクセストークンが保存されます。
* また、ユーザーがログインしていることを示すUI変更も加えました。
* 保護されたURLを追加し、ログインしている場合のみアクセスできるようにしました。
* プロフィールページに一部のデータを表示しています。
* 既存のユーザーアカウントでログインできます。
 *メールアドレス: :player1@example.com
 *パスワード: password1
これらは /mock_server/mock/store ディレクトリ内にあります。
* .env ファイルに JWT_SECRET を追加する必要があります。