### PR TITLE
Feat/socket reconnection/timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,9 @@ services:
       - "${NEXT_PUBLIC_SOCKET_PORT}:${NEXT_PUBLIC_SOCKET_PORT}"
     environment:
       - NODE_ENV=${NODE_ENV}
-      - PORT=${NEXSOCKET_PORT}
+      - PORT=${NEXT_PUBLIC_SOCKET_PORT}
+      - JWT_SECRET=${JWT_SECRET}
+      - RECONNECT_GRACE_MS=${RECONNECT_GRACE_MS:-30000}
     volumes:
       - ./socket_server:/app
       - /app/node_modules

--- a/frontend/app/game/components/CountdownOverlay.tsx
+++ b/frontend/app/game/components/CountdownOverlay.tsx
@@ -1,0 +1,14 @@
+type CountdownOverlayProps = {
+  seconds: number;
+};
+
+export function CountdownOverlay({ seconds }: CountdownOverlayProps) {
+  return (
+    <div className="absolute inset-0 z-30 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="flex flex-col items-center justify-center">
+        <span className="text-7xl font-extrabold text-white drop-shadow-lg">{seconds}</span>
+        <span className="mt-2 text-lg font-medium text-indigo-300">Get Ready!</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/game/components/GameResultOverlay.tsx
+++ b/frontend/app/game/components/GameResultOverlay.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+type GameResultOverlayProps = {
+  title: string;
+  description?: string | null;
+};
+
+export function GameResultOverlay({ title, description }: GameResultOverlayProps) {
+  return (
+    <div className="absolute inset-0 z-20 flex items-center justify-center bg-neutral-950/70 p-4 backdrop-blur-sm">
+      <div className="w-full max-w-sm rounded-2xl border border-neutral-700 bg-neutral-900/95 p-6 text-center shadow-2xl shadow-black/40">
+        <p className="text-xs font-semibold uppercase tracking-[0.25em] text-indigo-300">Match finished</p>
+        <h2 className="mt-3 text-2xl font-semibold text-white">{title}</h2>
+        {description ? <p className="mt-3 text-sm text-neutral-300">{description}</p> : null}
+        <Link
+          href="/lobby"
+          className="mt-6 inline-flex w-full items-center justify-center rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-indigo-500"
+        >
+          Return to Lobby
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/game/components/WorldScene.tsx
+++ b/frontend/app/game/components/WorldScene.tsx
@@ -8,7 +8,7 @@ import {
   SPAWN_DISTANCE as IMPORTED_SPAWN_DISTANCE,
   SPAWN_LINE_OFFSET,
 } from "../constants";
-import type { PlayerState } from "../types";
+import type { GameConstants, PlayerState } from "../types";
 
 const PLATE_THICKNESS = 0.5;
 const SPAWN_LINE_LENGTH = 3.6;
@@ -53,11 +53,7 @@ function FollowCamera({ target, heading }: FollowCameraProps) {
 type WorldSceneProps = {
   players: PlayerState[];
   localPlayerId: string | null;
-  gameConstants?: {
-    PLAYER_RADIUS: number;
-    SPAWN_DISTANCE: number;
-    WORLD_HALF: number;
-  } | null;
+  gameConstants?: GameConstants | null;
 };
 
 export function WorldScene({ players, localPlayerId, gameConstants }: WorldSceneProps) {

--- a/frontend/app/game/components/index.ts
+++ b/frontend/app/game/components/index.ts
@@ -1,0 +1,2 @@
+import type { CountdownOverlayProps } from "./CountdownOverlay";
+export { CountdownOverlay } from "./CountdownOverlay";

--- a/frontend/app/game/hooks/registerGameSessionSocketHandlers.ts
+++ b/frontend/app/game/hooks/registerGameSessionSocketHandlers.ts
@@ -1,0 +1,137 @@
+import type { Dispatch, SetStateAction } from "react";
+import type { Socket } from "socket.io-client";
+
+import type { GameConstants, PlayerState, RoomStatePayload } from "../types";
+
+type RegisterGameSessionSocketHandlersArgs = {
+  socket: Socket;
+  socketUrl: string;
+  onRoomCreated?: (roomId: string) => void;
+  setConnected: Dispatch<SetStateAction<boolean>>;
+  setJoinedRoomId: Dispatch<SetStateAction<string | null>>;
+  setLocalPlayerId: Dispatch<SetStateAction<string | null>>;
+  setPlayers: Dispatch<SetStateAction<PlayerState[]>>;
+  setErrorMessage: Dispatch<SetStateAction<string | null>>;
+  setSystemMessage: Dispatch<SetStateAction<string | null>>;
+  setRoundResultMessage: Dispatch<SetStateAction<string | null>>;
+  setSessionEndedReason: Dispatch<SetStateAction<string | null>>;
+  setIsPaused: Dispatch<SetStateAction<boolean>>;
+  setCountdown: Dispatch<SetStateAction<number | null>>;
+  setGameConstants: Dispatch<SetStateAction<GameConstants | null>>;
+};
+
+export function registerGameSessionSocketHandlers({
+  socket,
+  socketUrl,
+  onRoomCreated,
+  setConnected,
+  setJoinedRoomId,
+  setLocalPlayerId,
+  setPlayers,
+  setErrorMessage,
+  setSystemMessage,
+  setRoundResultMessage,
+  setSessionEndedReason,
+  setIsPaused,
+  setCountdown,
+  setGameConstants,
+}: RegisterGameSessionSocketHandlersArgs) {
+  const syncRoomState = ({ players: nextPlayers, status }: RoomStatePayload) => {
+    setPlayers(nextPlayers);
+    setIsPaused(status === "paused");
+  };
+
+  socket.on("connect", () => {
+    setConnected(true);
+    setErrorMessage(null);
+    socket.emit("reconnect");
+  });
+
+  socket.on("gameConstants", (constants: GameConstants) => {
+    setGameConstants(constants);
+  });
+
+  socket.on("disconnect", () => {
+    setConnected(false);
+    setSystemMessage("Connection lost. Trying to reconnect...");
+  });
+
+  socket.on("connect_error", (error) => {
+    setConnected(false);
+    const message = error?.message === "AUTH_MISSING_TOKEN" || error?.message === "AUTH_INVALID_TOKEN"
+      ? "Authentication failed. Please login again."
+      : `Unable to reach socket server at ${socketUrl}`;
+    setErrorMessage(message);
+  });
+
+  socket.on("roomCreated", ({ roomId }: { roomId: string }) => {
+    onRoomCreated?.(roomId);
+    setSystemMessage(`Room created: ${roomId}`);
+    setErrorMessage(null);
+  });
+
+  socket.on("joinedRoom", ({ roomId, playerId }: { roomId: string; playerId: string }) => {
+    setJoinedRoomId(roomId);
+    setLocalPlayerId(playerId);
+    setErrorMessage(null);
+    setRoundResultMessage(null);
+    setSessionEndedReason(null);
+    setSystemMessage(null);
+    setCountdown(null);
+  });
+
+  socket.on("game_state", syncRoomState);
+  socket.on("roomState", syncRoomState);
+
+  socket.on("roomError", ({ message }: { message: string }) => {
+    setErrorMessage(message);
+  });
+
+  socket.on("systemMessage", ({ message }: { message: string }) => {
+    setSystemMessage(message);
+  });
+
+  socket.on("opponent_disconnected", ({ timeoutMs }: { timeoutMs: number }) => {
+    setIsPaused(true);
+    setSystemMessage(`Opponent disconnected. Waiting up to ${Math.ceil(timeoutMs / 1000)} seconds...`);
+  });
+
+  socket.on("opponent_reconnected", () => {
+    setSystemMessage("Opponent reconnected.");
+  });
+
+  socket.on("countdown", ({ secondsRemaining }: { secondsRemaining: number }) => {
+    setCountdown(secondsRemaining);
+    if (secondsRemaining === 0) {
+      setIsPaused(false);
+    }
+  });
+
+  socket.on("session_ended", ({ reason, message }: { reason: string; message?: string }) => {
+    setSessionEndedReason(reason);
+    setIsPaused(false);
+    setJoinedRoomId(null);
+    setLocalPlayerId(null);
+    setPlayers([]);
+    setCountdown(null);
+
+    if (message) {
+      setSystemMessage(message);
+    }
+  });
+
+  socket.on("roundStarted", () => {
+    setSystemMessage(null);
+    setRoundResultMessage(null);
+    setCountdown(null);
+    setSessionEndedReason(null);
+  });
+
+  socket.on("result", ({ message }: { message: string }) => {
+    setRoundResultMessage(message);
+  });
+
+  socket.on("roundResult", ({ message }: { message: string }) => {
+    setRoundResultMessage(message);
+  });
+}

--- a/frontend/app/game/hooks/useGameSession.ts
+++ b/frontend/app/game/hooks/useGameSession.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { io, Socket } from "socket.io-client";
 
+import { getToken } from "@/lib/api";
 import { resolveSocketUrl } from "../socket-url";
-import type { PlayerState, RoomStatePayload } from "../types";
+import type { GameConstants, PlayerState } from "../types";
+import { registerGameSessionSocketHandlers } from "./registerGameSessionSocketHandlers";
 
 type CreateRoomArgs = {
   name: string;
@@ -27,16 +29,33 @@ export function useGameSession({ onRoomCreated }: UseGameSessionArgs = {}) {
   const [joinedRoomId, setJoinedRoomId] = useState<string | null>(null);
   const [localPlayerId, setLocalPlayerId] = useState<string | null>(null);
   const [players, setPlayers] = useState<PlayerState[]>([]);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    return getToken() ? null : "Please login first.";
+  });
   const [systemMessage, setSystemMessage] = useState<string | null>(null);
   const [roundResultMessage, setRoundResultMessage] = useState<string | null>(null);
-  const [gameConstants, setGameConstants] = useState<{ PLAYER_RADIUS: number; SPAWN_DISTANCE: number; WORLD_HALF: number } | null>(null);
+  const [sessionEndedReason, setSessionEndedReason] = useState<string | null>(null);
+  const [isPaused, setIsPaused] = useState(false);
+  const [countdown, setCountdown] = useState<number | null>(null);
+  const [gameConstants, setGameConstants] = useState<GameConstants | null>(null);
 
   useEffect(() => {
+    const token = getToken();
+
+    if (!token) {
+      return;
+    }
+
     const socket = io(socketUrl, {
       transports: ["websocket"],
       autoConnect: false,
+      auth: { token },
     });
+
     let disposed = false;
     const connectTimeout = window.setTimeout(() => {
       if (!disposed) {
@@ -46,62 +65,21 @@ export function useGameSession({ onRoomCreated }: UseGameSessionArgs = {}) {
 
     socketRef.current = socket;
 
-    socket.on("connect", () => {
-      setConnected(true);
-      setErrorMessage(null);
-    });
-
-    socket.on("gameConstants", ({ PLAYER_RADIUS, SPAWN_DISTANCE, WORLD_HALF }: { PLAYER_RADIUS: number; SPAWN_DISTANCE: number; WORLD_HALF: number }) => {
-      setGameConstants({ PLAYER_RADIUS, SPAWN_DISTANCE, WORLD_HALF });
-    });
-
-    socket.on("disconnect", () => {
-      setConnected(false);
-      setJoinedRoomId(null);
-      setLocalPlayerId(null);
-      setPlayers([]);
-      setSystemMessage(null);
-      setRoundResultMessage(null);
-    });
-
-    socket.on("connect_error", () => {
-      setConnected(false);
-      setErrorMessage(`Unable to reach socket server at ${socketUrl}`);
-    });
-
-    socket.on("roomCreated", ({ roomId }: { roomId: string }) => {
-      onRoomCreated?.(roomId);
-      setSystemMessage(`Room created: ${roomId}`);
-      setErrorMessage(null);
-    });
-
-    socket.on("joinedRoom", ({ roomId: activeRoomId, playerId }: { roomId: string; playerId: string }) => {
-      setJoinedRoomId(activeRoomId);
-      setLocalPlayerId(playerId);
-      setErrorMessage(null);
-      setSystemMessage(null);
-      setRoundResultMessage(null);
-    });
-
-    socket.on("roomState", ({ players: nextPlayers }: RoomStatePayload) => {
-      setPlayers(nextPlayers);
-    });
-
-    socket.on("roomError", ({ message }: { message: string }) => {
-      setErrorMessage(message);
-    });
-
-    socket.on("systemMessage", ({ message }: { message: string }) => {
-      setSystemMessage(message);
-    });
-
-    socket.on("roundStarted", () => {
-      setSystemMessage(null);
-      setRoundResultMessage(null);
-    });
-
-    socket.on("roundResult", ({ message }: { message: string }) => {
-      setRoundResultMessage(message);
+    registerGameSessionSocketHandlers({
+      socket,
+      socketUrl,
+      onRoomCreated,
+      setConnected,
+      setJoinedRoomId,
+      setLocalPlayerId,
+      setPlayers,
+      setErrorMessage,
+      setSystemMessage,
+      setRoundResultMessage,
+      setSessionEndedReason,
+      setIsPaused,
+      setCountdown,
+      setGameConstants,
     });
 
     return () => {
@@ -147,7 +125,7 @@ export function useGameSession({ onRoomCreated }: UseGameSessionArgs = {}) {
         return;
       }
 
-      socketRef.current?.emit("joinRoom", {
+      socketRef.current?.emit("join", {
         roomId,
         password,
         name,
@@ -163,6 +141,8 @@ export function useGameSession({ onRoomCreated }: UseGameSessionArgs = {}) {
     setPlayers([]);
     setSystemMessage(null);
     setRoundResultMessage(null);
+    setCountdown(null);
+    setSessionEndedReason(null);
   }, []);
 
   return {
@@ -174,6 +154,9 @@ export function useGameSession({ onRoomCreated }: UseGameSessionArgs = {}) {
     errorMessage,
     systemMessage,
     roundResultMessage,
+    sessionEndedReason,
+    isPaused,
+    countdown,
     gameConstants,
     setErrorMessage,
     setSystemMessage,

--- a/frontend/app/game/hooks/useMovementInput.ts
+++ b/frontend/app/game/hooks/useMovementInput.ts
@@ -9,6 +9,15 @@ type InputState = {
   right: boolean;
 };
 
+function createEmptyInputState(): InputState {
+  return {
+    up: false,
+    down: false,
+    left: false,
+    right: false,
+  };
+}
+
 export function useMovementInput({
   joinedRoomId,
   socketRef,
@@ -16,15 +25,11 @@ export function useMovementInput({
   joinedRoomId: string | null;
   socketRef: MutableRefObject<Socket | null>;
 }) {
-  const inputRef = useRef<InputState>({
-    up: false,
-    down: false,
-    left: false,
-    right: false,
-  });
+  const inputRef = useRef<InputState>(createEmptyInputState());
 
   useEffect(() => {
     if (!joinedRoomId) {
+      inputRef.current = createEmptyInputState();
       return;
     }
 
@@ -59,14 +64,15 @@ export function useMovementInput({
       const x = Number(inputRef.current.right) - Number(inputRef.current.left);
       const z = Number(inputRef.current.down) - Number(inputRef.current.up);
 
-      socket?.emit("moveInput", { x, z });
+      socket?.emit("move", { x, z });
     }, 1000 / 30);
 
     return () => {
       window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("keyup", onKeyUp);
       clearInterval(sendInput);
-      socket?.emit("moveInput", { x: 0, z: 0 });
+      inputRef.current = createEmptyInputState();
+      socket?.emit("move", { x: 0, z: 0 });
     };
   }, [joinedRoomId, socketRef]);
 }

--- a/frontend/app/game/multiplayer/page.tsx
+++ b/frontend/app/game/multiplayer/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { Canvas } from "@react-three/fiber";
 
+import { GameResultOverlay } from "@/app/game/components/GameResultOverlay";
 import { GameLobbyControls } from "../components/GameLobbyControls";
 import { WorldScene } from "../components/WorldScene";
 import { useGameSession } from "../hooks/useGameSession";
@@ -22,6 +23,7 @@ export default function GamePage() {
     errorMessage,
     systemMessage,
     roundResultMessage,
+    sessionEndedReason,
     gameConstants,
     createRoom,
     joinRoom,
@@ -37,6 +39,9 @@ export default function GamePage() {
   const handleJoinRoom = () => {
     joinRoom({ roomId, password, name });
   };
+
+  const showGameResult = sessionEndedReason === "game_finished";
+  const resultTitle = roundResultMessage ?? "Match finished";
 
   return (
     <main className="min-h-screen bg-neutral-950 text-neutral-100">
@@ -69,10 +74,11 @@ export default function GamePage() {
           onLeaveRoom={leaveRoom}
         />
 
-        <div className="h-[72vh] overflow-hidden rounded-lg border border-neutral-700">
+        <div className="relative h-[72vh] overflow-hidden rounded-lg border border-neutral-700">
           <Canvas shadows camera={{ position: [0, 8, 10], fov: 55 }}>
             <WorldScene players={players} localPlayerId={localPlayerId} gameConstants={gameConstants} />
           </Canvas>
+          {showGameResult ? <GameResultOverlay title={resultTitle} description={systemMessage} /> : null}
         </div>
       </section>
     </main>

--- a/frontend/app/game/multiplayer/page.tsx
+++ b/frontend/app/game/multiplayer/page.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Canvas } from "@react-three/fiber";
 
 import { GameResultOverlay } from "@/app/game/components/GameResultOverlay";
+import { CountdownOverlay } from "@/app/game/components/CountdownOverlay";
 import { GameLobbyControls } from "../components/GameLobbyControls";
 import { WorldScene } from "../components/WorldScene";
 import { useGameSession } from "../hooks/useGameSession";
@@ -24,6 +25,8 @@ export default function GamePage() {
     systemMessage,
     roundResultMessage,
     sessionEndedReason,
+    isPaused,
+    countdown,
     gameConstants,
     createRoom,
     joinRoom,
@@ -78,6 +81,7 @@ export default function GamePage() {
           <Canvas shadows camera={{ position: [0, 8, 10], fov: 55 }}>
             <WorldScene players={players} localPlayerId={localPlayerId} gameConstants={gameConstants} />
           </Canvas>
+          {countdown && countdown > 0 ? <CountdownOverlay seconds={countdown} /> : null}
           {showGameResult ? <GameResultOverlay title={resultTitle} description={systemMessage} /> : null}
         </div>
       </section>

--- a/frontend/app/game/solo/page.tsx
+++ b/frontend/app/game/solo/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { Canvas } from "@react-three/fiber";
 
+import { GameResultOverlay } from "@/app/game/components/GameResultOverlay";
 import { WorldScene } from "../components/WorldScene";
 import { useGameSession } from "../hooks/useGameSession";
 import { useMovementInput } from "../hooks/useMovementInput";
@@ -22,6 +23,7 @@ export default function SoloPage() {
 		errorMessage,
 		systemMessage,
 		roundResultMessage,
+		sessionEndedReason,
 		gameConstants,
 		leaveRoom,
 	} = useGameSession();
@@ -31,6 +33,9 @@ export default function SoloPage() {
 	const handleStart = () => {
 		socketRef.current?.emit("soloStart", { name, difficulty });
 	};
+
+	const showGameResult = sessionEndedReason === "game_finished";
+	const resultTitle = roundResultMessage ?? "Match finished";
 
 	return (
 		<main className="min-h-screen bg-neutral-950 text-neutral-100">
@@ -95,10 +100,11 @@ export default function SoloPage() {
 				{systemMessage && !errorMessage && <p className="text-sm text-neutral-400">{systemMessage}</p>}
 				{roundResultMessage && <p className="text-sm font-medium text-yellow-400">{roundResultMessage}</p>}
 
-				<div className="h-[70vh] overflow-hidden rounded-lg border border-neutral-700">
+				<div className="relative h-[70vh] overflow-hidden rounded-lg border border-neutral-700">
 					<Canvas shadows="basic" camera={{ position: [0, 8, 10], fov: 55 }}>
 						<WorldScene players={players} localPlayerId={localPlayerId} gameConstants={gameConstants} />
 					</Canvas>
+					{showGameResult ? <GameResultOverlay title={resultTitle} description={systemMessage} /> : null}
 				</div>
 
 				<p className="text-center text-xs text-neutral-600">WASD / arrow keys to move</p>

--- a/frontend/app/game/solo/page.tsx
+++ b/frontend/app/game/solo/page.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Canvas } from "@react-three/fiber";
 
 import { GameResultOverlay } from "@/app/game/components/GameResultOverlay";
+import { CountdownOverlay } from "@/app/game/components/CountdownOverlay";
 import { WorldScene } from "../components/WorldScene";
 import { useGameSession } from "../hooks/useGameSession";
 import { useMovementInput } from "../hooks/useMovementInput";
@@ -24,6 +25,8 @@ export default function SoloPage() {
 		systemMessage,
 		roundResultMessage,
 		sessionEndedReason,
+		isPaused,
+		countdown,
 		gameConstants,
 		leaveRoom,
 	} = useGameSession();
@@ -104,6 +107,7 @@ export default function SoloPage() {
 					<Canvas shadows="basic" camera={{ position: [0, 8, 10], fov: 55 }}>
 						<WorldScene players={players} localPlayerId={localPlayerId} gameConstants={gameConstants} />
 					</Canvas>
+					{countdown && countdown > 0 ? <CountdownOverlay seconds={countdown} /> : null}
 					{showGameResult ? <GameResultOverlay title={resultTitle} description={systemMessage} /> : null}
 				</div>
 

--- a/frontend/app/game/types.ts
+++ b/frontend/app/game/types.ts
@@ -1,12 +1,23 @@
 export type PlayerState = {
   id: string;
+  userId?: string;
   name: string;
   position: { x: number; y: number; z: number };
   velocity: { x: number; z: number };
   heading: number;
+  eliminated?: boolean;
+  disconnected?: boolean;
+};
+
+export type GameConstants = {
+  PLAYER_RADIUS: number;
+  SPAWN_DISTANCE: number;
+  WORLD_HALF: number;
 };
 
 export type RoomStatePayload = {
   roomId: string;
+  tick?: number;
+  status?: "waiting" | "active" | "paused";
   players: PlayerState[];
 };

--- a/socket_server/config.js
+++ b/socket_server/config.js
@@ -1,4 +1,6 @@
 const PORT = process.env.PORT || 3001;
+const JWT_SECRET = process.env.JWT_SECRET || "mock-super-secret-dev-key";
+const RECONNECT_GRACE_MS = Number(process.env.RECONNECT_GRACE_MS || 30000);
 
 const SOCKET_CORS = {
   origin: "*",
@@ -7,5 +9,7 @@ const SOCKET_CORS = {
 
 module.exports = {
   PORT,
+  JWT_SECRET,
+  RECONNECT_GRACE_MS,
   SOCKET_CORS,
 };

--- a/socket_server/game/player-utils.js
+++ b/socket_server/game/player-utils.js
@@ -1,8 +1,4 @@
-const {
-  PLAYER_RADIUS,
-  SPAWN_DISTANCE,
-  PLATE_SURFACE_Y,
-} = require("./constants");
+const { PLAYER_RADIUS, SPAWN_DISTANCE, PLATE_SURFACE_Y } = require("./constants");
 
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
@@ -16,9 +12,11 @@ function sanitizeName(name) {
   return (name || "Player").trim() || "Player";
 }
 
-function makePlayer(id, name) {
+function makePlayer({ userId, socketId, name }) {
   return {
-    id,
+    id: userId,
+    userId,
+    socketId,
     name,
     position: { x: 0, y: PLAYER_RADIUS, z: 0 },
     velocity: { x: 0, z: 0 },
@@ -27,14 +25,17 @@ function makePlayer(id, name) {
     fallVelocityY: 0,
     isCpu: false,
     eliminated: false,
+    disconnected: false,
     roundResult: null,
   };
 }
 
 function makeCPUball(id, name) {
   return {
-    id, 
-    name, 
+    id,
+    userId: id,
+    socketId: null,
+    name,
     position: { x: 0, y: PLATE_SURFACE_Y, z: 0 },
     velocity: { x: 0, z: 0 },
     input: { x: 0, z: 0 },
@@ -42,9 +43,9 @@ function makeCPUball(id, name) {
     fallVelocityY: 0,
     isCpu: true,
     eliminated: false,
+    disconnected: false,
     roundResult: null,
   };
-
 }
 
 function makeRoom(password) {
@@ -52,8 +53,12 @@ function makeRoom(password) {
     id: randomRoomId(),
     password,
     players: new Map(),
+    playerBySocketId: new Map(),
+    reconnectTimeouts: new Map(),
     interval: null,
     roundInProgress: false,
+    paused: false,
+    tickCount: 0,
     solo: false,
   };
 }
@@ -70,7 +75,7 @@ function placePlayerAtSpawnSlot(player, slotIndex) {
 }
 
 function placePlayersForRound(room) {
-  const players = [...room.players.values()];
+  const players = [...room.players.values()].filter((player) => !player.isCpu);
   players.forEach((player, index) => {
     placePlayerAtSpawnSlot(player, index);
   });
@@ -84,6 +89,7 @@ function resetPlayerForRound(player) {
   player.fallVelocityY = 0;
   player.position.y = PLATE_SURFACE_Y;
   player.eliminated = false;
+  player.disconnected = false;
   player.roundResult = null;
 }
 
@@ -97,11 +103,13 @@ function stopPlayerHorizontalMovement(player) {
 function serializePlayers(playersMap) {
   return [...playersMap.values()].map((player) => ({
     id: player.id,
+    userId: player.userId,
     name: player.name,
     position: player.position,
     velocity: player.velocity,
     heading: player.heading,
     eliminated: player.eliminated,
+    disconnected: player.disconnected,
   }));
 }
 

--- a/socket_server/game/room-round-manager.js
+++ b/socket_server/game/room-round-manager.js
@@ -256,14 +256,25 @@ function createRoomRoundManager({
 
     placePlayersForRound(room);
     room.tickCount = 0;
-    room.roundInProgress = true;
     room.paused = false;
-    io.to(room.id).emit("roundStarted", { roomId: room.id });
-    io.to(room.id).emit("countdown", { secondsRemaining: 0, reason: "round_start" });
-    io.to(room.id).emit("systemMessage", {
-      message: "Round started! Last player on the plate wins.",
-    });
-    emitGameState(room);
+
+    // Countdown sequence before round starts
+    let secondsRemaining = 3;
+    const countdownTick = () => {
+      io.to(room.id).emit("countdown", { secondsRemaining, reason: "round_start" });
+      if (secondsRemaining === 0) {
+        room.roundInProgress = true;
+        io.to(room.id).emit("roundStarted", { roomId: room.id });
+        io.to(room.id).emit("systemMessage", {
+          message: "Round started! Last player on the plate wins.",
+        });
+        emitGameState(room);
+        return;
+      }
+      secondsRemaining -= 1;
+      setTimeout(countdownTick, 1000);
+    };
+    countdownTick();
     return true;
   }
 
@@ -284,14 +295,25 @@ function createRoomRoundManager({
     const soloOpponent = makeSoloOpponent(room);
     room.players.set(soloOpponent.id, soloOpponent);
 
-    room.roundInProgress = true;
     room.paused = false;
-    io.to(room.id).emit("roundStarted", { roomId: room.id });
-    io.to(room.id).emit("countdown", { secondsRemaining: 0, reason: "round_start" });
-    io.to(room.id).emit("systemMessage", {
-      message: `Solo — opponent: ${room.soloDifficulty}.`,
-    });
-    emitGameState(room);
+
+    // Countdown sequence before solo round starts
+    let secondsRemaining = 3;
+    const countdownTick = () => {
+      io.to(room.id).emit("countdown", { secondsRemaining, reason: "round_start" });
+      if (secondsRemaining === 0) {
+        room.roundInProgress = true;
+        io.to(room.id).emit("roundStarted", { roomId: room.id });
+        io.to(room.id).emit("systemMessage", {
+          message: `Solo — opponent: ${room.soloDifficulty}.`,
+        });
+        emitGameState(room);
+        return;
+      }
+      secondsRemaining -= 1;
+      setTimeout(countdownTick, 1000);
+    };
+    countdownTick();
     return true;
   }
 

--- a/socket_server/game/room-round-manager.js
+++ b/socket_server/game/room-round-manager.js
@@ -1,0 +1,309 @@
+const {
+  TICK_MS,
+  FALL_ELIMINATION_Y,
+  PLATE_SURFACE_Y,
+  SOLO_CPU_ID,
+} = require("./constants");
+const {
+  clamp,
+  placePlayerAtSpawnSlot,
+  placePlayersForRound,
+  resetPlayerForRound,
+  stopPlayerHorizontalMovement,
+} = require("./player-utils");
+const {
+  resolveBallCollision,
+  applyFalling,
+  isPlayerOnPlate,
+  applyMovementInput,
+  capHorizontalSpeed,
+  applyHorizontalFriction,
+  advanceHorizontalPosition,
+} = require("./physics-utils");
+
+const GAME_FINISH_REASON = "game_finished";
+
+function normalizeAngle(angle) {
+  let normalized = angle;
+
+  while (normalized > Math.PI) {
+    normalized -= Math.PI * 2;
+  }
+
+  while (normalized < -Math.PI) {
+    normalized += Math.PI * 2;
+  }
+
+  return normalized;
+}
+
+function createRoomRoundManager({
+  io,
+  emitGameState,
+  countHumanPlayers,
+  normalizeSoloDifficulty,
+  makeSoloOpponent,
+  getSoloDifficultyConfig,
+  endSession,
+}) {
+  function notifyWaitingForOpponent(room) {
+    if (room.roundInProgress || countHumanPlayers(room) !== 1) {
+      return;
+    }
+
+    io.to(room.id).emit("systemMessage", {
+      message: "Waiting for opponent...",
+    });
+  }
+
+  function emitRoundResult(player, result, message) {
+    if (player.roundResult) {
+      return;
+    }
+
+    player.roundResult = result;
+
+    if (player.socketId) {
+      io.to(player.socketId).emit("result", { result, message });
+      io.to(player.socketId).emit("roundResult", { result, message });
+    }
+  }
+
+  function emitLoss(player) {
+    emitRoundResult(player, "lost", "You lose!");
+  }
+
+  function emitWin(player) {
+    emitRoundResult(player, "won", "You won!");
+  }
+
+  function endRoundIfNeeded(room) {
+    if (!room.roundInProgress || room.paused) {
+      return false;
+    }
+
+    const alivePlayers = [...room.players.values()].filter((player) => !player.eliminated);
+
+    if (alivePlayers.length > 1) {
+      return false;
+    }
+
+    if (alivePlayers.length === 1) {
+      const winner = alivePlayers[0];
+      emitWin(winner);
+      endSession(room, {
+        reason: GAME_FINISH_REASON,
+        message: `${winner.name} is the winner!`,
+      });
+      return true;
+    }
+
+    endSession(room, {
+      reason: GAME_FINISH_REASON,
+      message: "Round ended with no winner.",
+    });
+    return true;
+  }
+
+  function eliminatePlayer(room, player) {
+    if (player.eliminated) {
+      return;
+    }
+
+    player.eliminated = true;
+    stopPlayerHorizontalMovement(player);
+
+    if (!player.isCpu) {
+      emitLoss(player);
+    }
+
+    io.to(room.id).emit("systemMessage", {
+      message: `${player.name} fell off the plate!`,
+    });
+  }
+
+  function tickPlayer(room, player, dt) {
+    if (player.disconnected) {
+      stopPlayerHorizontalMovement(player);
+      return;
+    }
+
+    if (player.eliminated) {
+      applyFalling(player, dt);
+      return;
+    }
+
+    applyMovementInput(player, dt);
+    capHorizontalSpeed(player);
+    applyHorizontalFriction(player);
+    advanceHorizontalPosition(player, dt);
+
+    if (!isPlayerOnPlate(player)) {
+      stopPlayerHorizontalMovement(player);
+      applyFalling(player, dt);
+
+      if (player.position.y <= FALL_ELIMINATION_Y) {
+        eliminatePlayer(room, player);
+      }
+      return;
+    }
+
+    player.position.y = PLATE_SURFACE_Y;
+    player.fallVelocityY = 0;
+  }
+
+  function resolveActiveCollisions(players) {
+    const activePlayers = players.filter((player) => !player.eliminated && !player.disconnected);
+
+    for (let index = 0; index < activePlayers.length; index += 1) {
+      for (let comparisonIndex = index + 1; comparisonIndex < activePlayers.length; comparisonIndex += 1) {
+        resolveBallCollision(activePlayers[index], activePlayers[comparisonIndex]);
+      }
+    }
+  }
+
+  function updateSoloCpuInput(room) {
+    if (!room.solo || !room.roundInProgress || room.paused) {
+      return;
+    }
+
+    const cpu = room.players.get(SOLO_CPU_ID);
+    if (!cpu || cpu.eliminated) {
+      return;
+    }
+
+    const target = [...room.players.values()].find(
+      (player) => !player.isCpu && !player.eliminated && !player.disconnected
+    );
+
+    if (!target) {
+      cpu.input.x = 0;
+      cpu.input.z = 0;
+      return;
+    }
+
+    const config = getSoloDifficultyConfig(room.soloDifficulty);
+    const targetX = target.position.x + target.velocity.x * config.predictionTime;
+    const targetZ = target.position.z + target.velocity.z * config.predictionTime;
+    const dx = targetX - cpu.position.x;
+    const dz = targetZ - cpu.position.z;
+    const distance = Math.hypot(dx, dz);
+
+    const desiredHeading = Math.atan2(dx, -dz);
+    const headingDelta = normalizeAngle(desiredHeading - cpu.heading);
+    const headingAbs = Math.abs(headingDelta);
+    const baseTurn = clamp((headingDelta / (Math.PI / 3)) * config.turnGain, -1, 1);
+    const wobble = Math.sin((room.tickCount || 0) * config.wobbleFreq) * config.wobbleAmp;
+    cpu.input.x = clamp(baseTurn + wobble, -1, 1);
+
+    const alignment = Math.max(0, Math.cos(headingAbs));
+    let throttle = config.maxThrottle * (0.5 + Math.min(distance / 6, 0.5));
+
+    if (headingAbs > 0.95) {
+      throttle = config.pivotThrottle;
+    }
+
+    if (distance < config.brakeDistance) {
+      throttle = config.brakeThrottle;
+    }
+
+    if (alignment > 0.92 && distance > 1.6) {
+      throttle = config.maxThrottle;
+    }
+
+    throttle += alignment * config.chargeBoost;
+    throttle = clamp(throttle, 0.16, config.maxThrottle);
+    cpu.input.z = -throttle;
+  }
+
+  function tickRoom(room) {
+    if (!room.roundInProgress) {
+      return;
+    }
+
+    if (room.paused) {
+      emitGameState(room);
+      return;
+    }
+
+    const players = [...room.players.values()];
+    const dt = TICK_MS / 1000;
+    room.tickCount = (room.tickCount || 0) + 1;
+
+    updateSoloCpuInput(room);
+
+    for (const player of players) {
+      tickPlayer(room, player, dt);
+    }
+
+    resolveActiveCollisions(players);
+
+    if (endRoundIfNeeded(room)) {
+      return;
+    }
+
+    emitGameState(room);
+  }
+
+  function tryStartRound(room) {
+    if (room.roundInProgress || countHumanPlayers(room) < 2) {
+      return false;
+    }
+
+    for (const player of room.players.values()) {
+      resetPlayerForRound(player);
+    }
+
+    placePlayersForRound(room);
+    room.tickCount = 0;
+    room.roundInProgress = true;
+    room.paused = false;
+    io.to(room.id).emit("roundStarted", { roomId: room.id });
+    io.to(room.id).emit("countdown", { secondsRemaining: 0, reason: "round_start" });
+    io.to(room.id).emit("systemMessage", {
+      message: "Round started! Last player on the plate wins.",
+    });
+    emitGameState(room);
+    return true;
+  }
+
+  function startSoloRound(room, difficulty = "medium") {
+    if (room.roundInProgress) {
+      return false;
+    }
+
+    room.solo = true;
+    room.soloDifficulty = normalizeSoloDifficulty(difficulty);
+    room.tickCount = 0;
+
+    for (const player of room.players.values()) {
+      resetPlayerForRound(player);
+      placePlayerAtSpawnSlot(player, 0);
+    }
+
+    const soloOpponent = makeSoloOpponent(room);
+    room.players.set(soloOpponent.id, soloOpponent);
+
+    room.roundInProgress = true;
+    room.paused = false;
+    io.to(room.id).emit("roundStarted", { roomId: room.id });
+    io.to(room.id).emit("countdown", { secondsRemaining: 0, reason: "round_start" });
+    io.to(room.id).emit("systemMessage", {
+      message: `Solo — opponent: ${room.soloDifficulty}.`,
+    });
+    emitGameState(room);
+    return true;
+  }
+
+  return {
+    endRoundIfNeeded,
+    notifyWaitingForOpponent,
+    startSoloRound,
+    tickRoom,
+    tryStartRound,
+  };
+}
+
+module.exports = {
+  createRoomRoundManager,
+};

--- a/socket_server/game/room-service.js
+++ b/socket_server/game/room-service.js
@@ -2,8 +2,6 @@ const {
   TICK_RATE,
   TICK_MS,
   MAX_PLAYERS_PER_ROOM,
-  FALL_ELIMINATION_Y,
-  PLATE_SURFACE_Y,
   SOLO_CPU_DIFFICULTY,
   SOLO_CPU_ID,
 } = require("./constants");
@@ -14,39 +12,14 @@ const {
   makeCPUball,
   makeRoom,
   placePlayerAtSpawnSlot,
-  placePlayersForRound,
-  resetPlayerForRound,
-  stopPlayerHorizontalMovement,
   serializePlayers,
 } = require("./player-utils");
-const {
-  resolveBallCollision,
-  applyFalling,
-  isPlayerOnPlate,
-  applyMovementInput,
-  capHorizontalSpeed,
-  applyHorizontalFriction,
-  advanceHorizontalPosition,
-} = require("./physics-utils");
-
-
-
-function normalizeAngle(angle) {
-  let normalized = angle;
-
-  while (normalized > Math.PI) {
-    normalized -= Math.PI * 2;
-  }
-
-  while (normalized < -Math.PI) {
-    normalized += Math.PI * 2;
-  }
-
-  return normalized;
-}
+const { createRoomRoundManager } = require("./room-round-manager");
+const { createRoomSessionManager } = require("./room-session-manager");
 
 function createRoomService(io) {
   const rooms = new Map();
+  const userSessions = new Map();
 
   function normalizeSoloDifficulty(difficulty) {
     if (Object.hasOwn(SOLO_CPU_DIFFICULTY, difficulty)) {
@@ -67,55 +40,36 @@ function createRoomService(io) {
     return SOLO_CPU_DIFFICULTY[difficulty] || SOLO_CPU_DIFFICULTY.medium;
   }
 
-  function updateSoloCpuInput(room) {
-    if (!room.solo || !room.roundInProgress) {
-      return;
+  function countHumanPlayers(room) {
+    return [...room.players.values()].filter((player) => !player.isCpu).length;
+  }
+
+  function hasDisconnectedHuman(room) {
+    return [...room.players.values()].some((player) => !player.isCpu && player.disconnected);
+  }
+
+  function buildGameState(room) {
+    return {
+      roomId: room.id,
+      tick: room.tickCount,
+      status: room.paused ? "paused" : room.roundInProgress ? "active" : "waiting",
+      players: serializePlayers(room.players),
+    };
+  }
+
+  function emitGameState(room) {
+    const payload = buildGameState(room);
+    io.to(room.id).emit("game_state", payload);
+    io.to(room.id).emit("roomState", payload);
+  }
+
+  function findRoomByUserId(userId) {
+    const session = userSessions.get(userId);
+    if (!session) {
+      return null;
     }
 
-    const cpu = room.players.get(SOLO_CPU_ID);
-    if (!cpu || cpu.eliminated) {
-      return;
-    }
-
-    const target = [...room.players.values()].find((player) => !player.isCpu && !player.eliminated);
-    if (!target) {
-      cpu.input.x = 0;
-      cpu.input.z = 0;
-      return;
-    }
-
-    const config = getSoloDifficultyConfig(room.soloDifficulty);
-    const targetX = target.position.x + target.velocity.x * config.predictionTime;
-    const targetZ = target.position.z + target.velocity.z * config.predictionTime;
-    const dx = targetX - cpu.position.x;
-    const dz = targetZ - cpu.position.z;
-    const distance = Math.hypot(dx, dz);
-
-    const desiredHeading = Math.atan2(dx, -dz);
-    const headingDelta = normalizeAngle(desiredHeading - cpu.heading);
-    const headingAbs = Math.abs(headingDelta);
-    const baseTurn = clamp((headingDelta / (Math.PI / 3)) * config.turnGain, -1, 1);
-    const wobble = Math.sin((room.tickCount || 0) * config.wobbleFreq) * config.wobbleAmp;
-    cpu.input.x = clamp(baseTurn + wobble, -1, 1);
-
-    const alignment = Math.max(0, Math.cos(headingAbs));
-    let throttle = config.maxThrottle * (0.5 + Math.min(distance / 6, 0.5));
-
-    if (headingAbs > 0.95) {
-      throttle = config.pivotThrottle;
-    }
-
-    if (distance < config.brakeDistance) {
-      throttle = config.brakeThrottle;
-    }
-
-    if (alignment > 0.92 && distance > 1.6) {
-      throttle = config.maxThrottle;
-    }
-
-    throttle += alignment * config.chargeBoost;
-    throttle = clamp(throttle, 0.16, config.maxThrottle);
-    cpu.input.z = -throttle;
+    return rooms.get(session.roomId) || null;
   }
 
   function removeRoom(roomId) {
@@ -128,143 +82,86 @@ function createRoomService(io) {
       clearInterval(room.interval);
     }
 
+    sessionManager.clearAllReconnectTimers(room);
+
+    for (const player of room.players.values()) {
+      if (!player.isCpu) {
+        userSessions.delete(player.userId);
+      }
+    }
+
     rooms.delete(roomId);
   }
 
-  function broadcastRoomState(room) {
-    io.to(room.id).emit("roomState", {
-      roomId: room.id,
-      players: serializePlayers(room.players),
-    });
+  function removeHumanPlayer(room, userId) {
+    const player = room.players.get(userId) || null;
+    if (!player) {
+      return null;
+    }
+
+    sessionManager.clearReconnectTimer(room, userId);
+
+    if (player.socketId) {
+      room.playerBySocketId.delete(player.socketId);
+    }
+
+    room.players.delete(userId);
+    userSessions.delete(userId);
+
+    return player;
   }
 
-  function notifyWaitingForOpponent(room) {
-    if (room.roundInProgress || room.players.size !== 1) {
-      return;
+  function handleLeave(roomId, userId) {
+    const room = rooms.get(roomId);
+    if (!room) {
+      return { room: null, player: null, removedRoom: false };
     }
 
-    io.to(room.id).emit("systemMessage", {
-      message: "Waiting for opponent...",
-    });
-  }
+    const player = removeHumanPlayer(room, userId);
 
-  function emitRoundResult(player, result, message) {
-    if (player.roundResult) {
-      return;
-    }
-
-    player.roundResult = result;
-    io.to(player.id).emit("roundResult", {
-      result,
-      message,
-    });
-  }
-
-  function emitLoss(player) {
-    emitRoundResult(player, "lost", "You lose!");
-  }
-
-  function emitWin(player) {
-    emitRoundResult(player, "won", "You won!");
-  }
-
-  function endRoundIfNeeded(room) {
-    if (!room.roundInProgress) {
-      return;
-    }
-
-    const alivePlayers = [...room.players.values()].filter((player) => !player.eliminated);
-
-    if (alivePlayers.length > 1) {
-      return;
-    }
-
-    room.roundInProgress = false;
-
-    if (alivePlayers.length === 1) {
-      const winner = alivePlayers[0];
-      emitWin(winner);
-      io.to(room.id).emit("systemMessage", {
-        message: `${winner.name} is the winner!`,
-      });
-      return;
-    }
-
-    io.to(room.id).emit("systemMessage", {
-      message: "Round ended with no winner.",
-    });
-  }
-
-  function eliminatePlayer(room, player) {
-    if (player.eliminated) {
-      return;
-    }
-
-    player.eliminated = true;
-    stopPlayerHorizontalMovement(player);
-
-    if (!player.isCpu) {
-      emitLoss(player);
-    }
-    io.to(room.id).emit("systemMessage", {
-      message: `${player.name} fell off the plate!`,
-    });
-  }
-
-  function tickPlayer(room, player, dt) {
-    if (player.eliminated) {
-      applyFalling(player, dt);
-      return;
-    }
-
-    applyMovementInput(player, dt);
-    capHorizontalSpeed(player);
-    applyHorizontalFriction(player);
-    advanceHorizontalPosition(player, dt);
-
-    if (!isPlayerOnPlate(player)) {
-      stopPlayerHorizontalMovement(player);
-      applyFalling(player, dt);
-
-      if (player.position.y <= FALL_ELIMINATION_Y) {
-        eliminatePlayer(room, player);
-      }
-      return;
-    }
-
-    player.position.y = PLATE_SURFACE_Y;
-    player.fallVelocityY = 0;
-  }
-
-  function resolveActiveCollisions(players) {
-    const activePlayers = players.filter((player) => !player.eliminated);
-
-    for (let i = 0; i < activePlayers.length; i += 1) {
-      for (let j = i + 1; j < activePlayers.length; j += 1) {
-        resolveBallCollision(activePlayers[i], activePlayers[j]);
+    if (room.solo) {
+      const hasHumanPlayer = [...room.players.values()].some((currentPlayer) => !currentPlayer.isCpu);
+      if (!hasHumanPlayer) {
+        removeRoom(roomId);
+        return { room: null, player, removedRoom: true };
       }
     }
-  }
 
-  function tickRoom(room) {
-    if (!room.roundInProgress) {
-      return;
+    if (countHumanPlayers(room) === 0) {
+      removeRoom(roomId);
+      return { room: null, player, removedRoom: true };
     }
 
-    const players = [...room.players.values()];
-    const dt = TICK_MS / 1000;
-    room.tickCount = (room.tickCount || 0) + 1;
+    room.paused = false;
 
-    updateSoloCpuInput(room);
-
-    for (const player of players) {
-      tickPlayer(room, player, dt);
+    if (roundManager.endRoundIfNeeded(room) || !rooms.has(room.id)) {
+      return { room: null, player, removedRoom: true };
     }
 
-    resolveActiveCollisions(players);
-    endRoundIfNeeded(room);
-    broadcastRoomState(room);
+    emitGameState(room);
+    return { room, player, removedRoom: false };
   }
+
+  const sessionManager = createRoomSessionManager({
+    io,
+    rooms,
+    userSessions,
+    removeRoom,
+    emitGameState,
+    findRoomByUserId,
+    hasDisconnectedHuman,
+    handleLeave,
+  });
+
+  const roundManager = createRoomRoundManager({
+    io,
+    emitGameState,
+    countHumanPlayers,
+    normalizeSoloDifficulty,
+    makeSoloOpponent,
+    getSoloDifficultyConfig,
+    endSession: sessionManager.endSession,
+  });
 
   function startRoomLoop(room) {
     if (room.interval) {
@@ -272,7 +169,7 @@ function createRoomService(io) {
     }
 
     room.interval = setInterval(() => {
-      tickRoom(room);
+      roundManager.tickRoom(room);
     }, TICK_MS);
   }
 
@@ -287,25 +184,46 @@ function createRoomService(io) {
     return rooms.get(roomId);
   }
 
-  function addPlayerToRoom(room, socketId, rawName) {
-    const player = makePlayer(socketId, sanitizeName(rawName));
-    placePlayerAtSpawnSlot(player, room.players.size);
-    room.players.set(socketId, player);
+  function addPlayerToRoom(room, { userId, socketId, rawName }) {
+    const existing = room.players.get(userId);
+
+    if (existing) {
+      if (existing.socketId) {
+        room.playerBySocketId.delete(existing.socketId);
+      }
+
+      existing.socketId = socketId;
+      existing.disconnected = false;
+      existing.name = sanitizeName(rawName || existing.name);
+      room.playerBySocketId.set(socketId, userId);
+      userSessions.set(userId, { roomId: room.id });
+      sessionManager.clearReconnectTimer(room, userId);
+      return existing;
+    }
+
+    const player = makePlayer({ userId, socketId, name: sanitizeName(rawName) });
+    const spawnIndex = countHumanPlayers(room);
+    placePlayerAtSpawnSlot(player, spawnIndex);
+
+    room.players.set(userId, player);
+    room.playerBySocketId.set(socketId, userId);
+    userSessions.set(userId, { roomId: room.id });
+
     return player;
   }
 
-  function setPlayerInput(roomId, socketId, x, z) {
+  function setPlayerInput(roomId, userId, x, z) {
     const room = rooms.get(roomId);
     if (!room) {
       return;
     }
 
-    const player = room.players.get(socketId);
+    const player = room.players.get(userId);
     if (!player) {
       return;
     }
 
-    if (!room.roundInProgress || player.eliminated) {
+    if (!room.roundInProgress || room.paused || player.eliminated || player.disconnected) {
       player.input.x = 0;
       player.input.z = 0;
       return;
@@ -315,85 +233,12 @@ function createRoomService(io) {
     player.input.z = clamp(Number(z) || 0, -1, 1);
   }
 
-  function tryStartRound(room) {
-    if (room.roundInProgress || room.players.size < 2) {
-      return false;
-    }
-
-    for (const player of room.players.values()) {
-      resetPlayerForRound(player);
-    }
-
-    placePlayersForRound(room);
-
-    room.roundInProgress = true;
-    io.to(room.id).emit("roundStarted", { roomId: room.id });
-    io.to(room.id).emit("systemMessage", {
-      message: "Round started! Last player on the plate wins.",
-    });
-    broadcastRoomState(room);
-    return true;
-  }
-
-  function startSoloRound(room, difficulty = "medium") {
-    if (room.roundInProgress) {
-      return false;
-    }
-
-    room.solo = true;
-    room.soloDifficulty = normalizeSoloDifficulty(difficulty);
-    room.tickCount = 0;
-
-    for (const player of room.players.values()) {
-      resetPlayerForRound(player);
-      placePlayerAtSpawnSlot(player, 0);
-    }
-
-    const soloOpponent = makeSoloOpponent(room);
-    room.players.set(soloOpponent.id, soloOpponent);
-
-    room.roundInProgress = true;
-    io.to(room.id).emit("roundStarted", { roomId: room.id });
-    io.to(room.id).emit("systemMessage", {
-      message: `Solo — opponent: ${room.soloDifficulty}.`,
-    });
-    broadcastRoomState(room);
-    return true;
-  }
-
-  function removePlayer(roomId, socketId) {
-    const room = rooms.get(roomId);
-    if (!room) {
-      return { room: null, player: null, removedRoom: false };
-    }
-
-    const player = room.players.get(socketId) || null;
-    room.players.delete(socketId);
-
-    if (room.solo) {
-      const hasHumanPlayer = [...room.players.values()].some((currentPlayer) => !currentPlayer.isCpu);
-
-      if (!hasHumanPlayer) {
-        removeRoom(roomId);
-        return { room: null, player, removedRoom: true };
-      }
-    }
-
-    if (room.players.size === 0) {
-      removeRoom(roomId);
-      return { room: null, player, removedRoom: true };
-    }
-
-    endRoundIfNeeded(room);
-    return { room, player, removedRoom: false };
-  }
-
   function isRoomPasswordValid(room, password) {
     return room.password === (password || "").trim();
   }
 
   function isRoomFull(room) {
-    return room.players.size >= MAX_PLAYERS_PER_ROOM;
+    return countHumanPlayers(room) >= MAX_PLAYERS_PER_ROOM;
   }
 
   function isRoundInProgress(room) {
@@ -404,16 +249,19 @@ function createRoomService(io) {
     TICK_RATE,
     createRoom,
     getRoom,
+    findRoomByUserId,
     addPlayerToRoom,
     setPlayerInput,
-    tryStartRound,
-    startSoloRound,
-    removePlayer,
+    tryStartRound: roundManager.tryStartRound,
+    startSoloRound: roundManager.startSoloRound,
+    handleLeave,
+    handleDisconnect: sessionManager.handleDisconnect,
+    reconnectPlayer: sessionManager.reconnectPlayer,
     isRoomPasswordValid,
     isRoomFull,
     isRoundInProgress,
-    notifyWaitingForOpponent,
-    broadcastRoomState,
+    notifyWaitingForOpponent: roundManager.notifyWaitingForOpponent,
+    broadcastRoomState: emitGameState,
     getRoomCount: () => rooms.size,
   };
 }

--- a/socket_server/game/room-session-manager.js
+++ b/socket_server/game/room-session-manager.js
@@ -1,0 +1,201 @@
+const { RECONNECT_GRACE_MS } = require("../config");
+const { stopPlayerHorizontalMovement } = require("./player-utils");
+
+function createRoomSessionManager({
+  io,
+  rooms,
+  userSessions,
+  removeRoom,
+  emitGameState,
+  findRoomByUserId,
+  hasDisconnectedHuman,
+  handleLeave,
+}) {
+  function clearReconnectTimer(room, userId) {
+    const timeoutId = room.reconnectTimeouts.get(userId);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      room.reconnectTimeouts.delete(userId);
+    }
+  }
+
+  function clearAllReconnectTimers(room) {
+    for (const timeoutId of room.reconnectTimeouts.values()) {
+      clearTimeout(timeoutId);
+    }
+
+    room.reconnectTimeouts.clear();
+  }
+
+  function removeSocketsFromRoom(room) {
+    for (const player of room.players.values()) {
+      if (player.isCpu || !player.socketId) {
+        continue;
+      }
+
+      const socket = io.sockets.sockets.get(player.socketId);
+      if (!socket) {
+        continue;
+      }
+
+      socket.leave(room.id);
+      socket.data.roomId = null;
+    }
+  }
+
+  function endSession(room, { reason, message, payload = {} }) {
+    if (!rooms.has(room.id)) {
+      return;
+    }
+
+    room.roundInProgress = false;
+    room.paused = false;
+
+    io.to(room.id).emit("session_ended", {
+      reason,
+      message,
+      ...payload,
+    });
+
+    if (message) {
+      io.to(room.id).emit("systemMessage", { message });
+    }
+
+    removeSocketsFromRoom(room);
+    removeRoom(room.id);
+  }
+
+  function endSessionForDisconnectTimeout(room, disconnectedUserId) {
+    if (!rooms.has(room.id) || !room.roundInProgress) {
+      return;
+    }
+
+    endSession(room, {
+      reason: "disconnect_timeout",
+      message: "Session ended because a player did not reconnect in time.",
+      payload: { userId: disconnectedUserId },
+    });
+  }
+
+  function scheduleReconnectTimeout(room, userId) {
+    clearReconnectTimer(room, userId);
+
+    const timeoutId = setTimeout(() => {
+      endSessionForDisconnectTimeout(room, userId);
+    }, RECONNECT_GRACE_MS);
+
+    room.reconnectTimeouts.set(userId, timeoutId);
+  }
+
+  function runResumeCountdown(room) {
+    let secondsRemaining = 3;
+
+    const countdownTick = () => {
+      io.to(room.id).emit("countdown", {
+        secondsRemaining,
+        reason: "reconnect_resume",
+      });
+
+      if (secondsRemaining === 0) {
+        room.paused = false;
+        io.to(room.id).emit("systemMessage", {
+          message: "Match resumed.",
+        });
+        emitGameState(room);
+        return;
+      }
+
+      secondsRemaining -= 1;
+      setTimeout(countdownTick, 1000);
+    };
+
+    countdownTick();
+  }
+
+  function handleDisconnect(roomId, userId) {
+    const room = rooms.get(roomId);
+    if (!room) {
+      return { room: null, player: null, removedRoom: false };
+    }
+
+    const player = room.players.get(userId);
+    if (!player) {
+      return { room, player: null, removedRoom: false };
+    }
+
+    if (room.solo) {
+      return handleLeave(roomId, userId);
+    }
+
+    const previousSocketId = player.socketId;
+    player.disconnected = true;
+    player.socketId = null;
+
+    if (previousSocketId) {
+      room.playerBySocketId.delete(previousSocketId);
+    }
+
+    stopPlayerHorizontalMovement(player);
+    room.paused = room.roundInProgress;
+
+    io.to(room.id).emit("opponent_disconnected", {
+      userId,
+      timeoutMs: RECONNECT_GRACE_MS,
+    });
+
+    io.to(room.id).emit("systemMessage", {
+      message: `${player.name} disconnected. Match paused.`,
+    });
+
+    emitGameState(room);
+
+    if (room.roundInProgress) {
+      scheduleReconnectTimeout(room, userId);
+    }
+
+    return { room, player, removedRoom: false };
+  }
+
+  function reconnectPlayer(userId, socketId) {
+    const room = findRoomByUserId(userId);
+    if (!room) {
+      return { ok: false, room: null, player: null };
+    }
+
+    const player = room.players.get(userId);
+    if (!player) {
+      return { ok: false, room: null, player: null };
+    }
+
+    if (player.socketId) {
+      room.playerBySocketId.delete(player.socketId);
+    }
+
+    player.socketId = socketId;
+    player.disconnected = false;
+    room.playerBySocketId.set(socketId, userId);
+
+    clearReconnectTimer(room, userId);
+
+    io.to(room.id).emit("opponent_reconnected", { userId });
+    emitGameState(room);
+
+    if (room.roundInProgress && room.paused && !hasDisconnectedHuman(room)) {
+      runResumeCountdown(room);
+    }
+
+    return { ok: true, room, player };
+  }
+
+  return {
+    clearReconnectTimer,
+    clearAllReconnectTimers,
+    endSession,
+    handleDisconnect,
+    reconnectPlayer,
+  };
+}
+
+module.exports = {
+  createRoomSessionManager,
+};

--- a/socket_server/index.js
+++ b/socket_server/index.js
@@ -1,8 +1,9 @@
 const express = require("express");
 const http = require("http");
 const cors = require("cors");
+const jwt = require("jsonwebtoken");
 const { Server } = require("socket.io");
-const { PORT, SOCKET_CORS } = require("./config");
+const { PORT, JWT_SECRET, SOCKET_CORS } = require("./config");
 const { createRoomService } = require("./game/room-service");
 const { registerSocketHandlers } = require("./socket-handlers");
 
@@ -12,6 +13,28 @@ app.use(cors());
 const server = http.createServer(app);
 const io = new Server(server, {
   cors: SOCKET_CORS,
+});
+
+io.use((socket, next) => {
+  const token = socket.handshake.auth?.token;
+
+  if (!token) {
+    return next(new Error("AUTH_MISSING_TOKEN"));
+  }
+
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+    const userId = payload?.sub;
+
+    if (!userId || typeof userId !== "string") {
+      return next(new Error("AUTH_INVALID_TOKEN"));
+    }
+
+    socket.data.userId = userId;
+    next();
+  } catch {
+    return next(new Error("AUTH_INVALID_TOKEN"));
+  }
 });
 
 const roomService = createRoomService(io);

--- a/socket_server/package.json
+++ b/socket_server/package.json
@@ -8,8 +8,9 @@
     "dev": "node --watch index.js"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.18.2",
-    "socket.io": "^4.7.5",
-    "cors": "^2.8.5"
+    "jsonwebtoken": "^9.0.2",
+    "socket.io": "^4.7.5"
   }
 }

--- a/socket_server/socket-handlers.js
+++ b/socket_server/socket-handlers.js
@@ -2,12 +2,24 @@ const { PLAYER_RADIUS, SPAWN_DISTANCE, WORLD_HALF } = require("./game/constants"
 
 function registerSocketHandlers(io, roomService) {
   io.on("connection", (socket) => {
-    // Send game constants to the client
+    const userId = socket.data.userId;
+
     socket.emit("gameConstants", {
       PLAYER_RADIUS,
       SPAWN_DISTANCE,
       WORLD_HALF,
     });
+
+    const reconnectResult = roomService.reconnectPlayer(userId, socket.id);
+    if (reconnectResult.ok && reconnectResult.room) {
+      socket.join(reconnectResult.room.id);
+      socket.data.roomId = reconnectResult.room.id;
+      socket.emit("joinedRoom", {
+        roomId: reconnectResult.room.id,
+        playerId: reconnectResult.player.userId,
+      });
+      socket.emit("systemMessage", { message: "Reconnected to active session." });
+    }
 
     socket.on("createRoom", ({ password, name }) => {
       const trimmedPassword = (password || "").trim();
@@ -21,21 +33,25 @@ function registerSocketHandlers(io, roomService) {
       socket.emit("roomCreated", { roomId: room.id });
       socket.emit("systemMessage", { message: `Room created: ${room.id}` });
 
-      roomService.addPlayerToRoom(room, socket.id, name);
+      const player = roomService.addPlayerToRoom(room, {
+        userId,
+        socketId: socket.id,
+        rawName: name,
+      });
 
       socket.join(room.id);
       socket.data.roomId = room.id;
 
-      socket.emit("joinedRoom", { roomId: room.id, playerId: socket.id });
+      socket.emit("joinedRoom", { roomId: room.id, playerId: player.userId });
       roomService.broadcastRoomState(room);
-      const started = roomService.tryStartRound(room);
 
+      const started = roomService.tryStartRound(room);
       if (!started) {
         roomService.notifyWaitingForOpponent(room);
       }
     });
 
-    socket.on("joinRoom", ({ roomId, password, name }) => {
+    const handleJoinRoom = ({ roomId, password, name }) => {
       const room = roomService.getRoom((roomId || "").trim());
 
       if (!room) {
@@ -58,17 +74,16 @@ function registerSocketHandlers(io, roomService) {
         return;
       }
 
-      if (roomService.isRoundInProgress(room)) {
-        socket.emit("roomError", { message: "Round already in progress. Please wait for next room." });
-        return;
-      }
-
-      const player = roomService.addPlayerToRoom(room, socket.id, name);
+      const player = roomService.addPlayerToRoom(room, {
+        userId,
+        socketId: socket.id,
+        rawName: name,
+      });
 
       socket.join(room.id);
       socket.data.roomId = room.id;
 
-      socket.emit("joinedRoom", { roomId: room.id, playerId: socket.id });
+      socket.emit("joinedRoom", { roomId: room.id, playerId: player.userId });
       socket.emit("systemMessage", { message: `Joined room: ${room.id}` });
       io.to(room.id).emit("systemMessage", { message: `${player.name} joined.` });
 
@@ -78,7 +93,10 @@ function registerSocketHandlers(io, roomService) {
       if (!started) {
         roomService.notifyWaitingForOpponent(room);
       }
-    });
+    };
+
+    socket.on("join", handleJoinRoom);
+    socket.on("joinRoom", handleJoinRoom);
 
     socket.on("soloStart", ({ name, difficulty }) => {
       if (socket.data.roomId) {
@@ -87,15 +105,29 @@ function registerSocketHandlers(io, roomService) {
 
       const soloPassword = Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
       const room = roomService.createRoom(soloPassword);
-      roomService.addPlayerToRoom(room, socket.id, name);
+
+      const player = roomService.addPlayerToRoom(room, {
+        userId,
+        socketId: socket.id,
+        rawName: name,
+      });
 
       socket.join(room.id);
       socket.data.roomId = room.id;
 
-      socket.emit("joinedRoom", { roomId: room.id, playerId: socket.id });
+      socket.emit("joinedRoom", { roomId: room.id, playerId: player.userId });
       socket.emit("systemMessage", { message: `Solo room created: ${room.id}` });
 
       roomService.startSoloRound(room, difficulty);
+    });
+
+    socket.on("move", ({ x, z }) => {
+      const roomId = socket.data.roomId;
+      if (!roomId) {
+        return;
+      }
+
+      roomService.setPlayerInput(roomId, userId, x, z);
     });
 
     socket.on("moveInput", ({ x, z }) => {
@@ -104,7 +136,21 @@ function registerSocketHandlers(io, roomService) {
         return;
       }
 
-      roomService.setPlayerInput(roomId, socket.id, x, z);
+      roomService.setPlayerInput(roomId, userId, x, z);
+    });
+
+    socket.on("reconnect", () => {
+      const result = roomService.reconnectPlayer(userId, socket.id);
+      if (!result.ok || !result.room) {
+        return;
+      }
+
+      socket.join(result.room.id);
+      socket.data.roomId = result.room.id;
+      socket.emit("joinedRoom", {
+        roomId: result.room.id,
+        playerId: result.player.userId,
+      });
     });
 
     socket.on("leaveRoom", () => {
@@ -113,13 +159,7 @@ function registerSocketHandlers(io, roomService) {
         return;
       }
 
-      const room = roomService.getRoom(roomId);
-      if (!room) {
-        socket.data.roomId = null;
-        return;
-      }
-
-      const result = roomService.removePlayer(roomId, socket.id);
+      const result = roomService.handleLeave(roomId, userId);
 
       socket.leave(roomId);
       socket.data.roomId = null;
@@ -140,17 +180,13 @@ function registerSocketHandlers(io, roomService) {
         return;
       }
 
-      const result = roomService.removePlayer(roomId, socket.id);
-      if (!result.player) {
+      const result = roomService.handleDisconnect(roomId, userId);
+
+      if (!result.player || !result.room) {
         return;
       }
 
-      io.to(roomId).emit("systemMessage", { message: `${result.player.name} disconnected.` });
-
-      if (result.room) {
-        roomService.broadcastRoomState(result.room);
-        roomService.notifyWaitingForOpponent(result.room);
-      }
+      roomService.broadcastRoomState(result.room);
     });
   });
 }


### PR DESCRIPTION
* adding re-connections and timeout to socket server.
* adding a count down timer before a match starts
*  adding game pause when a player disconnects
*you can add a RECONNECT_GRACE_MS to .env if you want to change the amount of time it takes for the session to time out. 
*updating .env.example to reflect new .env 
*merged mock/user_auth_api so there are no merge conflicts

* ソケットサーバーに再接続機能とタイムアウト機能を追加。
* 試合開始前のカウントダウンタイマーを追加
* プレイヤーが切断した際のゲーム一時停止機能を追加
* セッションのタイムアウト時間を変更したい場合は、.env に RECONNECT_GRACE_MS を追加できます。
* 新しい .env を反映するために .env.example を更新
* マージ競合が発生しないよう、mock/user_auth_api をマージ
