### PR TITLE
feat: add mawashi color and dohyo

### DIFF
--- a/frontend/app/game/components/CustomizationPanel.tsx
+++ b/frontend/app/game/components/CustomizationPanel.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import {
+  MAWASHI_COLORS,
+  DOHYO_THEMES,
+  type DohyoTheme,
+} from "../hooks/useCustomization";
+
+type CustomizationPanelProps = {
+  mawashiColor: string;
+  dohyoTheme: DohyoTheme;
+  onUpdate: (patch: { mawashiColor?: string; dohyoTheme?: DohyoTheme }) => void;
+};
+
+export function CustomizationPanel({ mawashiColor, dohyoTheme, onUpdate }: CustomizationPanelProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-4 rounded-lg border border-neutral-700 bg-neutral-900/60 px-4 py-3">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium text-neutral-400">Mawashi</span>
+        <div className="flex gap-1.5">
+          {MAWASHI_COLORS.map((c) => (
+            <button
+              key={c.value}
+              title={c.label}
+              onClick={() => onUpdate({ mawashiColor: c.value })}
+              className={`h-6 w-6 rounded-full border-2 transition ${
+                mawashiColor === c.value
+                  ? "border-white scale-110"
+                  : "border-neutral-600 hover:border-neutral-400"
+              }`}
+              style={{ backgroundColor: c.value }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="h-5 w-px bg-neutral-700" />
+
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium text-neutral-400">Dohyo</span>
+        <div className="flex gap-1.5">
+          {(Object.entries(DOHYO_THEMES) as [DohyoTheme, (typeof DOHYO_THEMES)[DohyoTheme]][]).map(
+            ([key, theme]) => (
+              <button
+                key={key}
+                title={theme.label}
+                onClick={() => onUpdate({ dohyoTheme: key })}
+                className={`h-6 w-6 rounded border-2 transition ${
+                  dohyoTheme === key
+                    ? "border-white scale-110"
+                    : "border-neutral-600 hover:border-neutral-400"
+                }`}
+                style={{ backgroundColor: theme.surface }}
+              />
+            )
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/game/components/WorldScene.tsx
+++ b/frontend/app/game/components/WorldScene.tsx
@@ -9,6 +9,7 @@ import {
   SPAWN_LINE_OFFSET,
 } from "../constants";
 import type { GameConstants, PlayerState } from "../types";
+import { DOHYO_THEMES, type DohyoTheme } from "../hooks/useCustomization";
 import DashCooldownIndicator from "./DashCooldownIndicator";
 
 const PLATE_THICKNESS = 0.5;
@@ -57,14 +58,18 @@ type WorldSceneProps = {
   dashCooldownMs?: number;
   dashCooldownTotalMs?: number;
   gameConstants?: GameConstants | null;
+  mawashiColor?: string;
+  dohyoTheme?: DohyoTheme;
 };
 
-export function WorldScene({ players, localPlayerId, dashCooldownMs, dashCooldownTotalMs, gameConstants }: WorldSceneProps) {
+export function WorldScene({ players, localPlayerId, dashCooldownMs, dashCooldownTotalMs, gameConstants, mawashiColor = "#3b82f6", dohyoTheme = "default" }: WorldSceneProps) {
   // Use passed constants or fallback to imports (for backwards compatibility)
   const PLAYER_RADIUS = gameConstants?.PLAYER_RADIUS ?? IMPORTED_PLAYER_RADIUS;
   const SPAWN_DISTANCE = gameConstants?.SPAWN_DISTANCE ?? IMPORTED_SPAWN_DISTANCE;
   const WORLD_SIZE = gameConstants?.WORLD_HALF ? gameConstants.WORLD_HALF * 2 : 22;
   const PLATE_RADIUS = WORLD_SIZE / 2;
+
+  const theme = DOHYO_THEMES[dohyoTheme];
 
   const localPlayer = useMemo(
     () => players.find((player) => player.id === localPlayerId) || null,
@@ -88,17 +93,17 @@ export function WorldScene({ players, localPlayerId, dashCooldownMs, dashCooldow
 
       <mesh position={[0, -PLATE_THICKNESS / 2, 0]} receiveShadow>
         <cylinderGeometry args={[PLATE_RADIUS, PLATE_RADIUS, PLATE_THICKNESS, 80]} />
-        <meshStandardMaterial color="#2f2f2f" />
+        <meshStandardMaterial color={theme.surface} />
       </mesh>
 
       <mesh position={[0, 0.02, SPAWN_DISTANCE - SPAWN_LINE_OFFSET]} receiveShadow>
         <boxGeometry args={[SPAWN_LINE_LENGTH, SPAWN_LINE_THICKNESS, 0.18]} />
-        <meshStandardMaterial color="#f5f5f5" emissive="#737373" emissiveIntensity={0.3} />
+        <meshStandardMaterial color={theme.border} emissive={theme.border} emissiveIntensity={0.3} />
       </mesh>
 
       <mesh position={[0, 0.02, -SPAWN_DISTANCE + SPAWN_LINE_OFFSET]} receiveShadow>
         <boxGeometry args={[SPAWN_LINE_LENGTH, SPAWN_LINE_THICKNESS, 0.18]} />
-        <meshStandardMaterial color="#f5f5f5" emissive="#737373" emissiveIntensity={0.3} />
+        <meshStandardMaterial color={theme.border} emissive={theme.border} emissiveIntensity={0.3} />
       </mesh>
 
       {players.map((player) => {
@@ -111,7 +116,7 @@ export function WorldScene({ players, localPlayerId, dashCooldownMs, dashCooldow
           >
             <mesh castShadow>
               <sphereGeometry args={[PLAYER_RADIUS, 24, 24]} />
-              <meshStandardMaterial color={isSelf ? "#3b82f6" : "#f97316"} />
+              <meshStandardMaterial color={isSelf ? mawashiColor : "#f97316"} />
             </mesh>
             {isSelf ? (
               <DashCooldownIndicator dashCooldownMs={dashCooldownMs} dashCooldownTotalMs={dashCooldownTotalMs} offsetY={PLAYER_RADIUS + 0.5} />

--- a/frontend/app/game/hooks/useCustomization.ts
+++ b/frontend/app/game/hooks/useCustomization.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export type DohyoTheme = "default" | "sand" | "night" | "clay";
+
+export type CustomizationState = {
+  mawashiColor: string;
+  dohyoTheme: DohyoTheme;
+};
+
+const STORAGE_KEY = "sumoverse-customization";
+
+const DEFAULT_STATE: CustomizationState = {
+  mawashiColor: "#3b82f6",
+  dohyoTheme: "default",
+};
+
+export const MAWASHI_COLORS = [
+  { value: "#3b82f6", label: "Blue" },
+  { value: "#ef4444", label: "Red" },
+  { value: "#10b981", label: "Green" },
+  { value: "#f59e0b", label: "Gold" },
+  { value: "#8b5cf6", label: "Purple" },
+  { value: "#ec4899", label: "Pink" },
+  { value: "#f5f5f5", label: "White" },
+  { value: "#171717", label: "Black" },
+];
+
+export const DOHYO_THEMES: Record<DohyoTheme, { label: string; surface: string; border: string }> = {
+  default: { label: "Default", surface: "#2f2f2f", border: "#f5f5f5" },
+  sand:    { label: "Sand",    surface: "#c2a97e", border: "#8b7355" },
+  night:   { label: "Night",   surface: "#1a1a2e", border: "#4a4a8a" },
+  clay:    { label: "Clay",    surface: "#8b4513", border: "#d2b48c" },
+};
+
+function loadFromStorage(): CustomizationState {
+  if (typeof window === "undefined") return DEFAULT_STATE;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_STATE;
+    return { ...DEFAULT_STATE, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULT_STATE;
+  }
+}
+
+export function useCustomization() {
+  const [state, setState] = useState<CustomizationState>(DEFAULT_STATE);
+
+  useEffect(() => {
+    setState(loadFromStorage());
+  }, []);
+
+  const update = useCallback((patch: Partial<CustomizationState>) => {
+    setState((prev) => {
+      const next = { ...prev, ...patch };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
+  return { ...state, update };
+}

--- a/frontend/app/game/multiplayer/page.tsx
+++ b/frontend/app/game/multiplayer/page.tsx
@@ -12,7 +12,9 @@ import { useGameSession } from "../hooks/useGameSession";
 import { useMovementInput } from "../hooks/useMovementInput";
 import { useDashCooldown } from "../hooks/useDashCooldown";
 import { FrameRateDisplay } from "../components/FrameRateDispay";
+import { CustomizationPanel } from "../components/CustomizationPanel";
 import { FpsCounter } from "../utils/FpsCounter";
+import { useCustomization } from "../hooks/useCustomization";
 
 export default function GamePage() {
   const [name, setName] = useState("Player");
@@ -37,6 +39,7 @@ export default function GamePage() {
     leaveRoom,
   } = useGameSession({ onRoomCreated: setRoomId });
 
+  const { mawashiColor, dohyoTheme, update: updateCustomization } = useCustomization();
   const dashCooldownTotalMs = gameConstants?.DASH_COOLDOWN_MS ?? 800;
   const { dashCooldownMs, triggerDash } = useDashCooldown(dashCooldownTotalMs);
   useMovementInput({ joinedRoomId, socketRef, onDash: triggerDash });
@@ -65,6 +68,8 @@ export default function GamePage() {
           </Link>
         </div>
 
+        <CustomizationPanel mawashiColor={mawashiColor} dohyoTheme={dohyoTheme} onUpdate={updateCustomization} />
+
         <GameLobbyControls
           name={name}
           roomId={roomId}
@@ -92,6 +97,8 @@ export default function GamePage() {
               gameConstants={gameConstants}
               dashCooldownMs={dashCooldownMs}
               dashCooldownTotalMs={dashCooldownTotalMs}
+              mawashiColor={mawashiColor}
+              dohyoTheme={dohyoTheme}
             />
           </Canvas>
           <FrameRateDisplay fps={fps} />

--- a/frontend/app/game/solo/page.tsx
+++ b/frontend/app/game/solo/page.tsx
@@ -11,7 +11,9 @@ import { useGameSession } from "../hooks/useGameSession";
 import { useMovementInput } from "../hooks/useMovementInput";
 import { useDashCooldown } from "../hooks/useDashCooldown";
 import { FrameRateDisplay } from "../components/FrameRateDispay";
+import { CustomizationPanel } from "../components/CustomizationPanel";
 import { FpsCounter } from "../utils/FpsCounter";
+import { useCustomization } from "../hooks/useCustomization";
 
 type SoloDifficulty = "dummy" | "easy" | "medium" | "hard";
 
@@ -35,6 +37,7 @@ export default function SoloPage() {
 		leaveRoom,
 	} = useGameSession();
 
+	const { mawashiColor, dohyoTheme, update: updateCustomization } = useCustomization();
 	const dashCooldownTotalMs = gameConstants?.DASH_COOLDOWN_MS ?? 800;
 	const { dashCooldownMs, triggerDash } = useDashCooldown(dashCooldownTotalMs);
 
@@ -106,6 +109,8 @@ export default function SoloPage() {
 					</div>
 				)}
 
+				<CustomizationPanel mawashiColor={mawashiColor} dohyoTheme={dohyoTheme} onUpdate={updateCustomization} />
+
 				{errorMessage && <p className="text-sm text-red-400">{errorMessage}</p>}
 				{systemMessage && !errorMessage && <p className="text-sm text-neutral-400">{systemMessage}</p>}
 				{roundResultMessage && <p className="text-sm font-medium text-yellow-400">{roundResultMessage}</p>}
@@ -119,6 +124,8 @@ export default function SoloPage() {
 							gameConstants={gameConstants}
 							dashCooldownMs={dashCooldownMs}
 							dashCooldownTotalMs={dashCooldownTotalMs}
+							mawashiColor={mawashiColor}
+							dohyoTheme={dohyoTheme}
 						/>
 					</Canvas>
 						<FrameRateDisplay fps={fps} />


### PR DESCRIPTION
  ## 概要
  力士の廻し色と土俵テーマを変更できるカスタマイズ機能を追加。
  選択はlocalStorageに保存され、ブラウザ内で永続化する

  ## 変更内容
  - 廻し色の選択UI（8色：青・赤・緑・金・紫・ピンク・白・黒）
  - 土俵テーマの選択UI（Default / Sand / Night / Clay）
  - Three.jsシーンへのカスタマイズ反映（自キャラの色・土俵の色）
  - ソロモード・マルチプレイヤー両方に対応
  
Closes #25 