### PR TITLE
feat: フレンド機能のAPI実装およびDB連携（申請・承諾/拒否・削除）

### DIFF
--- a/api_server/src/repository/friendRepository.ts
+++ b/api_server/src/repository/friendRepository.ts
@@ -1,11 +1,8 @@
 import { eq, or, and } from 'drizzle-orm';
-import { createDbClient } from './dbClient';
 import { friendRequests, friendships, users } from '../db/schema';
 
-const { db } = createDbClient();
-
 export const friendRepository = {
-  createRequest: async (senderId: string, receiverId: string) => {
+  createRequest: async (db: AppDb, senderId: string, receiverId: string) => {
     const result = await db.insert(friendRequests).values({
       senderId,
       receiverId,
@@ -14,7 +11,7 @@ export const friendRepository = {
     return result[0];
   },
 
-  getPendingRequestsByUserId: async (userId: string) => {
+  getPendingRequestsByUserId: async (db: AppDb, userId: string) => {
     return await db.select({
       id: friendRequests.id,
       senderId: friendRequests.senderId,
@@ -27,7 +24,7 @@ export const friendRepository = {
     .where(and(eq(friendRequests.receiverId, userId), eq(friendRequests.status, 'pending')));
   },
 
-  updateRequestStatus: async (requestId: string, status: 'accepted' | 'rejected') => {
+  updateRequestStatus: async (db: AppDb, requestId: string, status: 'accepted' | 'rejected') => {
     const result = await db.update(friendRequests)
       .set({ status, updatedAt: new Date() })
       .where(eq(friendRequests.id, requestId))
@@ -35,12 +32,12 @@ export const friendRepository = {
     return result[0];
   },
 
-  getRequestById: async (requestId: string) => {
+  getRequestById: async (db: AppDb, requestId: string) => {
     const result = await db.select().from(friendRequests).where(eq(friendRequests.id, requestId));
     return result[0];
   },
 
-  createFriendship: async (userId: string, friendId: string) => {
+  createFriendship: async (db: AppDb, userId: string, friendId: string) => {
     const result = await db.insert(friendships).values({
       userId,
       friendId,
@@ -49,7 +46,7 @@ export const friendRepository = {
     return result[0];
   },
 
-  getFriendsByUserId: async (userId: string) => {
+  getFriendsByUserId: async (db: AppDb, userId: string) => {
     return await db.select()
       .from(friendships)
       .where(
@@ -60,7 +57,7 @@ export const friendRepository = {
       );
   },
 
-  removeFriendship: async (userId: string, friendId: string) => {
+  removeFriendship: async (db: AppDb, userId: string, friendId: string) => {
     const result = await db.update(friendships)
       .set({ status: 'removed', updatedAt: new Date() })
       .where(

--- a/api_server/src/repository/friendRepository.ts
+++ b/api_server/src/repository/friendRepository.ts
@@ -1,0 +1,75 @@
+import { eq, or, and } from 'drizzle-orm';
+import { createDbClient } from './dbClient';
+import { friendRequests, friendships, users } from '../db/schema';
+
+const { db } = createDbClient();
+
+export const friendRepository = {
+  createRequest: async (senderId: string, receiverId: string) => {
+    const result = await db.insert(friendRequests).values({
+      senderId,
+      receiverId,
+      status: 'pending'
+    }).returning();
+    return result[0];
+  },
+
+  getPendingRequestsByUserId: async (userId: string) => {
+    return await db.select({
+      id: friendRequests.id,
+      senderId: friendRequests.senderId,
+      createdAt: friendRequests.createdAt,
+      senderNickname: users.nickname,
+      senderAvatar: users.avatarUrl
+    })
+    .from(friendRequests)
+    .innerJoin(users, eq(friendRequests.senderId, users.id))
+    .where(and(eq(friendRequests.receiverId, userId), eq(friendRequests.status, 'pending')));
+  },
+
+  updateRequestStatus: async (requestId: string, status: 'accepted' | 'rejected') => {
+    const result = await db.update(friendRequests)
+      .set({ status, updatedAt: new Date() })
+      .where(eq(friendRequests.id, requestId))
+      .returning();
+    return result[0];
+  },
+
+  getRequestById: async (requestId: string) => {
+    const result = await db.select().from(friendRequests).where(eq(friendRequests.id, requestId));
+    return result[0];
+  },
+
+  createFriendship: async (userId: string, friendId: string) => {
+    const result = await db.insert(friendships).values({
+      userId,
+      friendId,
+      status: 'accepted'
+    }).returning();
+    return result[0];
+  },
+
+  getFriendsByUserId: async (userId: string) => {
+    return await db.select()
+      .from(friendships)
+      .where(
+        and(
+          or(eq(friendships.userId, userId), eq(friendships.friendId, userId)),
+          eq(friendships.status, 'accepted')
+        )
+      );
+  },
+
+  removeFriendship: async (userId: string, friendId: string) => {
+    const result = await db.update(friendships)
+      .set({ status: 'removed', updatedAt: new Date() })
+      .where(
+        or(
+          and(eq(friendships.userId, userId), eq(friendships.friendId, friendId)),
+          and(eq(friendships.userId, friendId), eq(friendships.friendId, userId))
+        )
+      )
+      .returning();
+    return result;
+  }
+};

--- a/api_server/src/repository/friendRepository.ts
+++ b/api_server/src/repository/friendRepository.ts
@@ -65,12 +65,12 @@ export const friendRepository = {
   },
 
   createFriendship: async (db: AppDb, userId: string, friendId: string) => {
-    const result = await db.insert(friendships).values({
-      userId,
-      friendId,
-      status: 'accepted'
-    }).returning();
-    return result[0];
+    const result = await db.insert(friendships).values([
+      { userId: userId, friendId: friendId, status: 'accepted' },
+      { userId: friendId, friendId: userId, status: 'accepted' }
+    ]).returning();
+    
+    return result;
   },
 
   getFriendsByUserId: async (db: AppDb, userId: string) => {

--- a/api_server/src/repository/friendRepository.ts
+++ b/api_server/src/repository/friendRepository.ts
@@ -1,5 +1,6 @@
 import { eq, or, and } from 'drizzle-orm';
 import { friendRequests, friendships, users } from '../db/schema';
+import type { AppDb } from './dbClient';
 
 export const friendRepository = {
   createRequest: async (db: AppDb, senderId: string, receiverId: string) => {
@@ -8,6 +9,32 @@ export const friendRepository = {
       receiverId,
       status: 'pending'
     }).returning();
+    return result[0];
+  },
+
+  getPendingRequestBetweenUsers: async (db: AppDb, user1Id: string, user2Id: string) => {
+    const result = await db.select().from(friendRequests).where(
+      and(
+        eq(friendRequests.status, 'pending'),
+        or(
+          and(eq(friendRequests.senderId, user1Id), eq(friendRequests.receiverId, user2Id)),
+          and(eq(friendRequests.senderId, user2Id), eq(friendRequests.receiverId, user1Id))
+        )
+      )
+    );
+    return result[0];
+  },
+
+  getFriendshipBetweenUsers: async (db: AppDb, user1Id: string, user2Id: string) => {
+    const result = await db.select().from(friendships).where(
+      and(
+        eq(friendships.status, 'accepted'),
+        or(
+          and(eq(friendships.userId, user1Id), eq(friendships.friendId, user2Id)),
+          and(eq(friendships.userId, user2Id), eq(friendships.friendId, user1Id))
+        )
+      )
+    );
     return result[0];
   },
 

--- a/api_server/src/repository/friendRepository.ts
+++ b/api_server/src/repository/friendRepository.ts
@@ -3,6 +3,11 @@ import { friendRequests, friendships, users } from '../db/schema';
 import type { AppDb } from './dbClient';
 
 export const friendRepository = {
+  checkUserExists: async (db: AppDb, userId: string) => {
+    const result = await db.select().from(users).where(eq(users.id, userId));
+    return result.length > 0;
+  },
+
   createRequest: async (db: AppDb, senderId: string, receiverId: string) => {
     const result = await db.insert(friendRequests).values({
       senderId,

--- a/api_server/src/routes/friends/index.ts
+++ b/api_server/src/routes/friends/index.ts
@@ -29,7 +29,7 @@ friendsRoute.post('/requests', async (c) => {
       return c.json({ error: error.message }, error.statusCode as any);
     }
     const message = error instanceof Error ? error.message : "Failed to send friend request";
-    return c.json({ error: message }, 400);
+    return c.json({ error: message }, 500);
   }
 });
 

--- a/api_server/src/routes/friends/index.ts
+++ b/api_server/src/routes/friends/index.ts
@@ -9,16 +9,16 @@ friendsRoute.post('/requests', async (c) => {
     const body = await c.req.json().catch(() => null);
     
     if (!body) {
-      return c.json({ error: "Invalid JSON format" }, 400);
+      return c.json({ error: "Invalid JSON format" }, 422);
     }
 
     const { senderId, receiverId } = body; 
 
     if (!senderId || typeof senderId !== 'string') {
-      return c.json({ error: "senderId is required and must be a string" }, 400);
+      return c.json({ error: "senderId is required and must be a string" }, 422);
     }
     if (!receiverId || typeof receiverId !== 'string') {
-      return c.json({ error: "receiverId is required and must be a string" }, 400);
+      return c.json({ error: "receiverId is required and must be a string" }, 422);
     }
 
     const result = await friendService.sendFriendRequest(senderId, receiverId);
@@ -36,7 +36,7 @@ friendsRoute.post('/requests', async (c) => {
 friendsRoute.get('/requests', async (c) => {
   try {
     const userId = c.req.query('userId');
-    if (!userId) return c.json({ error: "userId is required" }, 400);
+    if (!userId) return c.json({ error: "userId is required" }, 422);
 
     const requests = await friendService.getPendingRequests(userId);
     return c.json(requests, 200);
@@ -55,7 +55,7 @@ friendsRoute.post('/requests/:id/accept', async (c) => {
     
     const body = await c.req.json().catch(() => null);
     if (!body || !body.userId || typeof body.userId !== 'string') {
-      return c.json({ error: "userId is required in body and must be a string" }, 400);
+      return c.json({ error: "userId is required in body and must be a string" }, 422);
     }
 
     const result = await friendService.acceptFriendRequest(body.userId, requestId);
@@ -75,7 +75,7 @@ friendsRoute.post('/requests/:id/reject', async (c) => {
     
     const body = await c.req.json().catch(() => null);
     if (!body || !body.userId || typeof body.userId !== 'string') {
-      return c.json({ error: "userId is required in body and must be a string" }, 400);
+      return c.json({ error: "userId is required in body and must be a string" }, 422);
     }
 
     const result = await friendService.rejectFriendRequest(body.userId, requestId);
@@ -92,7 +92,7 @@ friendsRoute.post('/requests/:id/reject', async (c) => {
 friendsRoute.get('/', async (c) => {
   try {
     const userId = c.req.query('userId');
-    if (!userId) return c.json({ error: "userId is required" }, 400);
+    if (!userId) return c.json({ error: "userId is required" }, 422);
 
     const friends = await friendService.getFriendList(userId);
     return c.json(friends, 200);
@@ -111,13 +111,13 @@ friendsRoute.post('/:id/remove', async (c) => {
     
     const body = await c.req.json().catch(() => null);
     if (!body) {
-      return c.json({ error: "Invalid JSON format" }, 400);
+      return c.json({ error: "Invalid JSON format" }, 422);
     }
 
     const { userId } = body; 
     
     if (!userId || typeof userId !== 'string') {
-      return c.json({ error: "userId is required and must be a string" }, 400);
+      return c.json({ error: "userId is required and must be a string" }, 422);
     }
     
     const result = await friendService.removeFriend(userId, friendId);

--- a/api_server/src/routes/friends/index.ts
+++ b/api_server/src/routes/friends/index.ts
@@ -1,0 +1,72 @@
+import { Hono } from 'hono';
+import { friendService } from '../../service/friendService';
+
+export const friendsRoute = new Hono();
+
+friendsRoute.post('/requests', async (c) => {
+  try {
+    const body = await c.req.json();
+    const { senderId, receiverId } = body; 
+    const result = await friendService.sendFriendRequest(senderId, receiverId);
+    return c.json(result, 201);
+  } catch (error: any) {
+    return c.json({ error: error.message }, 400);
+  }
+});
+
+friendsRoute.get('/requests', async (c) => {
+  try {
+    const userId = c.req.query('userId');
+    if (!userId) return c.json({ error: "userId is required" }, 400);
+
+    const requests = await friendService.getPendingRequests(userId);
+    return c.json(requests, 200);
+  } catch (error: any) {
+    return c.json({ error: error.message }, 500);
+  }
+});
+
+friendsRoute.post('/requests/:id/accept', async (c) => {
+  try {
+    const requestId = c.req.param('id');
+    const result = await friendService.acceptFriendRequest(requestId);
+    return c.json(result, 200);
+  } catch (error: any) {
+    return c.json({ error: error.message }, 400);
+  }
+});
+
+friendsRoute.post('/requests/:id/reject', async (c) => {
+  try {
+    const requestId = c.req.param('id');
+    const result = await friendService.rejectFriendRequest(requestId);
+    return c.json(result, 200);
+  } catch (error: any) {
+    return c.json({ error: error.message }, 400);
+  }
+});
+
+friendsRoute.get('/', async (c) => {
+  try {
+    const userId = c.req.query('userId');
+    if (!userId) return c.json({ error: "userId is required" }, 400);
+
+    const friends = await friendService.getFriendList(userId);
+    return c.json(friends, 200);
+  } catch (error: any) {
+    return c.json({ error: error.message }, 500);
+  }
+});
+
+friendsRoute.post('/:id/remove', async (c) => {
+  try {
+    const friendId = c.req.param('id');
+    const body = await c.req.json();
+    const { userId } = body; 
+    
+    const result = await friendService.removeFriend(userId, friendId);
+    return c.json(result, 200);
+  } catch (error: any) {
+    return c.json({ error: error.message }, 400);
+  }
+});

--- a/api_server/src/routes/friends/index.ts
+++ b/api_server/src/routes/friends/index.ts
@@ -23,8 +23,9 @@ friendsRoute.post('/requests', async (c) => {
     const result = await friendService.sendFriendRequest(senderId, receiverId);
     return c.json(result, 201);
     
-  } catch (error: any) {
-    return c.json({ error: error.message }, 400);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to send friend request";
+    return c.json({ error: message }, 400);
   }
 });
 
@@ -35,8 +36,9 @@ friendsRoute.get('/requests', async (c) => {
 
     const requests = await friendService.getPendingRequests(userId);
     return c.json(requests, 200);
-  } catch (error: any) {
-    return c.json({ error: error.message }, 500);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to fetch friend requests";
+    return c.json({ error: message }, 500);
   }
 });
 
@@ -45,8 +47,9 @@ friendsRoute.post('/requests/:id/accept', async (c) => {
     const requestId = c.req.param('id');
     const result = await friendService.acceptFriendRequest(requestId);
     return c.json(result, 200);
-  } catch (error: any) {
-    return c.json({ error: error.message }, 400);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to accept friend request";
+    return c.json({ error: message }, 400);
   }
 });
 
@@ -55,8 +58,9 @@ friendsRoute.post('/requests/:id/reject', async (c) => {
     const requestId = c.req.param('id');
     const result = await friendService.rejectFriendRequest(requestId);
     return c.json(result, 200);
-  } catch (error: any) {
-    return c.json({ error: error.message }, 400);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to reject friend request";
+    return c.json({ error: message }, 400);
   }
 });
 
@@ -67,20 +71,31 @@ friendsRoute.get('/', async (c) => {
 
     const friends = await friendService.getFriendList(userId);
     return c.json(friends, 200);
-  } catch (error: any) {
-    return c.json({ error: error.message }, 500);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to fetch friend list";
+    return c.json({ error: message }, 500);
   }
 });
 
 friendsRoute.post('/:id/remove', async (c) => {
   try {
     const friendId = c.req.param('id');
-    const body = await c.req.json();
+    
+    const body = await c.req.json().catch(() => null);
+    if (!body) {
+      return c.json({ error: "Invalid JSON format" }, 400);
+    }
+
     const { userId } = body; 
+    
+    if (!userId || typeof userId !== 'string') {
+      return c.json({ error: "userId is required and must be a string" }, 400);
+    }
     
     const result = await friendService.removeFriend(userId, friendId);
     return c.json(result, 200);
-  } catch (error: any) {
-    return c.json({ error: error.message }, 400);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to remove friend";
+    return c.json({ error: message }, 400);
   }
 });

--- a/api_server/src/routes/friends/index.ts
+++ b/api_server/src/routes/friends/index.ts
@@ -5,10 +5,24 @@ export const friendsRoute = new Hono();
 
 friendsRoute.post('/requests', async (c) => {
   try {
-    const body = await c.req.json();
+    const body = await c.req.json().catch(() => null);
+    
+    if (!body) {
+      return c.json({ error: "Invalid JSON format" }, 400);
+    }
+
     const { senderId, receiverId } = body; 
+
+    if (!senderId || typeof senderId !== 'string') {
+      return c.json({ error: "senderId is required and must be a string" }, 400);
+    }
+    if (!receiverId || typeof receiverId !== 'string') {
+      return c.json({ error: "receiverId is required and must be a string" }, 400);
+    }
+
     const result = await friendService.sendFriendRequest(senderId, receiverId);
     return c.json(result, 201);
+    
   } catch (error: any) {
     return c.json({ error: error.message }, 400);
   }

--- a/api_server/src/routes/friends/index.ts
+++ b/api_server/src/routes/friends/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { friendService } from '../../service/friendService';
+import { ApiError } from '../../utils/apiError';
 
 export const friendsRoute = new Hono();
 
@@ -24,6 +25,9 @@ friendsRoute.post('/requests', async (c) => {
     return c.json(result, 201);
     
   } catch (error) {
+    if (error instanceof ApiError) {
+      return c.json({ error: error.message }, error.statusCode as any);
+    }
     const message = error instanceof Error ? error.message : "Failed to send friend request";
     return c.json({ error: message }, 400);
   }
@@ -37,6 +41,9 @@ friendsRoute.get('/requests', async (c) => {
     const requests = await friendService.getPendingRequests(userId);
     return c.json(requests, 200);
   } catch (error) {
+    if (error instanceof ApiError) {
+      return c.json({ error: error.message }, error.statusCode as any);
+    }
     const message = error instanceof Error ? error.message : "Failed to fetch friend requests";
     return c.json({ error: message }, 500);
   }
@@ -45,22 +52,40 @@ friendsRoute.get('/requests', async (c) => {
 friendsRoute.post('/requests/:id/accept', async (c) => {
   try {
     const requestId = c.req.param('id');
-    const result = await friendService.acceptFriendRequest(requestId);
+    
+    const body = await c.req.json().catch(() => null);
+    if (!body || !body.userId || typeof body.userId !== 'string') {
+      return c.json({ error: "userId is required in body and must be a string" }, 400);
+    }
+
+    const result = await friendService.acceptFriendRequest(body.userId, requestId);
     return c.json(result, 200);
   } catch (error) {
+    if (error instanceof ApiError) {
+      return c.json({ error: error.message }, error.statusCode as any);
+    }
     const message = error instanceof Error ? error.message : "Failed to accept friend request";
-    return c.json({ error: message }, 400);
+    return c.json({ error: message }, 500);
   }
 });
 
 friendsRoute.post('/requests/:id/reject', async (c) => {
   try {
     const requestId = c.req.param('id');
-    const result = await friendService.rejectFriendRequest(requestId);
+    
+    const body = await c.req.json().catch(() => null);
+    if (!body || !body.userId || typeof body.userId !== 'string') {
+      return c.json({ error: "userId is required in body and must be a string" }, 400);
+    }
+
+    const result = await friendService.rejectFriendRequest(body.userId, requestId);
     return c.json(result, 200);
   } catch (error) {
+    if (error instanceof ApiError) {
+      return c.json({ error: error.message }, error.statusCode as any);
+    }
     const message = error instanceof Error ? error.message : "Failed to reject friend request";
-    return c.json({ error: message }, 400);
+    return c.json({ error: message }, 500);
   }
 });
 
@@ -72,6 +97,9 @@ friendsRoute.get('/', async (c) => {
     const friends = await friendService.getFriendList(userId);
     return c.json(friends, 200);
   } catch (error) {
+    if (error instanceof ApiError) {
+      return c.json({ error: error.message }, error.statusCode as any);
+    }
     const message = error instanceof Error ? error.message : "Failed to fetch friend list";
     return c.json({ error: message }, 500);
   }
@@ -95,7 +123,10 @@ friendsRoute.post('/:id/remove', async (c) => {
     const result = await friendService.removeFriend(userId, friendId);
     return c.json(result, 200);
   } catch (error) {
+    if (error instanceof ApiError) {
+      return c.json({ error: error.message }, error.statusCode as any);
+    }
     const message = error instanceof Error ? error.message : "Failed to remove friend";
-    return c.json({ error: message }, 400);
+    return c.json({ error: message }, 500);
   }
 });

--- a/api_server/src/routes/index.ts
+++ b/api_server/src/routes/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { friendsRoute } from "./friends/index";
 import { analysisRoutes } from "./analysis/index";
 import { adminRoutes } from "./admin/index";
 import { mockRoutes } from "./mock/index";
@@ -8,6 +9,7 @@ const app = new Hono()
     .route("/mock", mockRoutes)
     .route("/analysis", analysisRoutes)
     .route("/admin", adminRoutes)
+    .route("/friends", friendsRoute)
     .get("/", (c) => {
         return c.text("This is the API root.");
     })

--- a/api_server/src/service/friendService.ts
+++ b/api_server/src/service/friendService.ts
@@ -34,13 +34,17 @@ export const friendService = {
     return { success: true, message: "Friend request rejected" };
   },
 
-  getFriendList: async (userId: string) => {
+getFriendList: async (userId: string) => {
     const friendships = await friendRepository.getFriendsByUserId(userId);
     
-    const friendIds = friendships.map(f => f.userId === userId ? f.friendId : f.userId);
+    // 相手のIDだけを抽出（ここまでは重複が含まれている可能性がある）
+    const rawFriendIds = friendships.map(f => f.userId === userId ? f.friendId : f.userId);
+    
+    // 重複を削除 
+    const uniqueFriendIds = Array.from(new Set(rawFriendIds));
     
     // Socket連携前のモックとしてオフラインを返す
-    return friendIds.map(id => ({
+    return uniqueFriendIds.map(id => ({
       userId: id,
       onlineStatus: "offline"
     }));

--- a/api_server/src/service/friendService.ts
+++ b/api_server/src/service/friendService.ts
@@ -1,75 +1,101 @@
 import { friendRepository } from '../repository/friendRepository';
 import { ApiError } from '../utils/apiError';
+import { createDbClient } from '../repository/dbClient'; /
 
 export const friendService = {
   sendFriendRequest: async (senderId: string, receiverId: string) => {
-    if (senderId === receiverId) {
-      throw new ApiError(400, "Cannot send friend request to yourself");
+    const { db, close } = createDbClient(); 
+    try {
+      if (senderId === receiverId) {
+        throw new ApiError(400, "Cannot send friend request to yourself");
+      }
+      return await friendRepository.createRequest(db, senderId, receiverId);
+    } finally {
+      await close(); 
     }
-    return await friendRepository.createRequest(senderId, receiverId);
   },
 
   getPendingRequests: async (userId: string) => {
-    return await friendRepository.getPendingRequestsByUserId(userId);
+    const { db, close } = createDbClient();
+    try {
+      return await friendRepository.getPendingRequestsByUserId(db, userId);
+    } finally {
+      await close();
+    }
   },
 
   acceptFriendRequest: async (userId: string, requestId: string) => {
-    const request = await friendRepository.getRequestById(requestId);
-    
-    if (!request) {
-      throw new ApiError(404, "Friend request not found");
+    const { db, close } = createDbClient();
+    try {
+      const request = await friendRepository.getRequestById(db, requestId);
+      
+      if (!request) {
+        throw new ApiError(404, "Friend request not found");
+      }
+      if (request.receiverId !== userId) {
+        throw new ApiError(403, "You are not authorized to accept this request");
+      }
+      if (request.status !== 'pending') {
+        throw new ApiError(409, "Friend request already processed");
+      }
+      
+      await friendRepository.updateRequestStatus(db, requestId, 'accepted');
+      await friendRepository.createFriendship(db, request.senderId, request.receiverId);
+      
+      return { success: true, message: "Friend request accepted" };
+    } finally {
+      await close();
     }
-    if (request.receiverId !== userId) {
-      throw new ApiError(403, "You are not authorized to accept this request");
-    }
-    if (request.status !== 'pending') {
-      throw new ApiError(409, "Friend request already processed");
-    }
-    
-    await friendRepository.updateRequestStatus(requestId, 'accepted');
-    await friendRepository.createFriendship(request.senderId, request.receiverId);
-    
-    return { success: true, message: "Friend request accepted" };
   },
 
   rejectFriendRequest: async (userId: string, requestId: string) => {
-    const request = await friendRepository.getRequestById(requestId);
-    
-    if (!request) {
-      throw new ApiError(404, "Friend request not found");
+    const { db, close } = createDbClient();
+    try {
+      const request = await friendRepository.getRequestById(db, requestId);
+      
+      if (!request) {
+        throw new ApiError(404, "Friend request not found");
+      }
+      if (request.receiverId !== userId) {
+        throw new ApiError(403, "You are not authorized to reject this request");
+      }
+      if (request.status !== 'pending') {
+        throw new ApiError(409, "Friend request already processed");
+      }
+      
+      await friendRepository.updateRequestStatus(db, requestId, 'rejected');
+      return { success: true, message: "Friend request rejected" };
+    } finally {
+      await close();
     }
-    if (request.receiverId !== userId) {
-      throw new ApiError(403, "You are not authorized to reject this request");
-    }
-    if (request.status !== 'pending') {
-      throw new ApiError(409, "Friend request already processed");
-    }
-    
-    await friendRepository.updateRequestStatus(requestId, 'rejected');
-    return { success: true, message: "Friend request rejected" };
   },
 
   getFriendList: async (userId: string) => {
-    const friendships = await friendRepository.getFriendsByUserId(userId);
-    
-    // 相手のIDだけを抽出（ここまでは重複が含まれている可能性がある）
-    const rawFriendIds = friendships.map(f => f.userId === userId ? f.friendId : f.userId);
-    
-    // 重複を削除 
-    const uniqueFriendIds = Array.from(new Set(rawFriendIds));
-    
-    // Socket連携前のモックとしてオフラインを返す
-    return uniqueFriendIds.map(id => ({
-      userId: id,
-      onlineStatus: "offline"
-    }));
+    const { db, close } = createDbClient();
+    try {
+      const friendships = await friendRepository.getFriendsByUserId(db, userId);
+      const rawFriendIds = friendships.map(f => f.userId === userId ? f.friendId : f.userId);
+      const uniqueFriendIds = Array.from(new Set(rawFriendIds));
+      
+      return uniqueFriendIds.map(id => ({
+        userId: id,
+        onlineStatus: "offline"
+      }));
+    } finally {
+      await close();
+    }
   },
 
   removeFriend: async (userId: string, friendId: string) => {
-    const result = await friendRepository.removeFriendship(userId, friendId);
-    if (result.length === 0) {
-      throw new ApiError(404, "Friendship does not exist");
+    const { db, close } = createDbClient();
+    try {
+      const result = await friendRepository.removeFriendship(db, userId, friendId);
+      if (result.length === 0) {
+        throw new ApiError(404, "Friendship does not exist");
+      }
+      return { success: true, message: "Friend removed" };
+    } finally {
+      await close();
     }
-    return { success: true, message: "Friend removed" };
   }
 };

--- a/api_server/src/service/friendService.ts
+++ b/api_server/src/service/friendService.ts
@@ -1,0 +1,56 @@
+import { friendRepository } from '../repository/friendRepository';
+
+export const friendService = {
+  sendFriendRequest: async (senderId: string, receiverId: string) => {
+    if (senderId === receiverId) {
+      throw new Error("Cannot send friend request to yourself");
+    }
+    return await friendRepository.createRequest(senderId, receiverId);
+  },
+
+  getPendingRequests: async (userId: string) => {
+    return await friendRepository.getPendingRequestsByUserId(userId);
+  },
+
+  acceptFriendRequest: async (requestId: string) => {
+    const request = await friendRepository.getRequestById(requestId);
+    if (!request || request.status !== 'pending') {
+      throw new Error("Invalid or already processed request");
+    }
+    
+    await friendRepository.updateRequestStatus(requestId, 'accepted');
+    await friendRepository.createFriendship(request.senderId, request.receiverId);
+    
+    return { success: true, message: "Friend request accepted" };
+  },
+
+  rejectFriendRequest: async (requestId: string) => {
+    const request = await friendRepository.getRequestById(requestId);
+    if (!request || request.status !== 'pending') {
+      throw new Error("Invalid or already processed request");
+    }
+    
+    await friendRepository.updateRequestStatus(requestId, 'rejected');
+    return { success: true, message: "Friend request rejected" };
+  },
+
+  getFriendList: async (userId: string) => {
+    const friendships = await friendRepository.getFriendsByUserId(userId);
+    
+    const friendIds = friendships.map(f => f.userId === userId ? f.friendId : f.userId);
+    
+    // Socket連携前のモックとしてオフラインを返す
+    return friendIds.map(id => ({
+      userId: id,
+      onlineStatus: "offline"
+    }));
+  },
+
+  removeFriend: async (userId: string, friendId: string) => {
+    const result = await friendRepository.removeFriendship(userId, friendId);
+    if (result.length === 0) {
+      throw new Error("Friendship does not exist");
+    }
+    return { success: true, message: "Friend removed" };
+  }
+};

--- a/api_server/src/service/friendService.ts
+++ b/api_server/src/service/friendService.ts
@@ -1,9 +1,10 @@
 import { friendRepository } from '../repository/friendRepository';
+import { ApiError } from '../utils/apiError';
 
 export const friendService = {
   sendFriendRequest: async (senderId: string, receiverId: string) => {
     if (senderId === receiverId) {
-      throw new Error("Cannot send friend request to yourself");
+      throw new ApiError(400, "Cannot send friend request to yourself");
     }
     return await friendRepository.createRequest(senderId, receiverId);
   },
@@ -12,10 +13,17 @@ export const friendService = {
     return await friendRepository.getPendingRequestsByUserId(userId);
   },
 
-  acceptFriendRequest: async (requestId: string) => {
+  acceptFriendRequest: async (userId: string, requestId: string) => {
     const request = await friendRepository.getRequestById(requestId);
-    if (!request || request.status !== 'pending') {
-      throw new Error("Invalid or already processed request");
+    
+    if (!request) {
+      throw new ApiError(404, "Friend request not found");
+    }
+    if (request.receiverId !== userId) {
+      throw new ApiError(403, "You are not authorized to accept this request");
+    }
+    if (request.status !== 'pending') {
+      throw new ApiError(409, "Friend request already processed");
     }
     
     await friendRepository.updateRequestStatus(requestId, 'accepted');
@@ -24,17 +32,24 @@ export const friendService = {
     return { success: true, message: "Friend request accepted" };
   },
 
-  rejectFriendRequest: async (requestId: string) => {
+  rejectFriendRequest: async (userId: string, requestId: string) => {
     const request = await friendRepository.getRequestById(requestId);
-    if (!request || request.status !== 'pending') {
-      throw new Error("Invalid or already processed request");
+    
+    if (!request) {
+      throw new ApiError(404, "Friend request not found");
+    }
+    if (request.receiverId !== userId) {
+      throw new ApiError(403, "You are not authorized to reject this request");
+    }
+    if (request.status !== 'pending') {
+      throw new ApiError(409, "Friend request already processed");
     }
     
     await friendRepository.updateRequestStatus(requestId, 'rejected');
     return { success: true, message: "Friend request rejected" };
   },
 
-getFriendList: async (userId: string) => {
+  getFriendList: async (userId: string) => {
     const friendships = await friendRepository.getFriendsByUserId(userId);
     
     // 相手のIDだけを抽出（ここまでは重複が含まれている可能性がある）
@@ -53,7 +68,7 @@ getFriendList: async (userId: string) => {
   removeFriend: async (userId: string, friendId: string) => {
     const result = await friendRepository.removeFriendship(userId, friendId);
     if (result.length === 0) {
-      throw new Error("Friendship does not exist");
+      throw new ApiError(404, "Friendship does not exist");
     }
     return { success: true, message: "Friend removed" };
   }

--- a/api_server/src/service/friendService.ts
+++ b/api_server/src/service/friendService.ts
@@ -59,7 +59,13 @@ export const friendService = {
       }
       
       await friendRepository.updateRequestStatus(db, requestId, 'accepted');
-      await friendRepository.createFriendship(db, request.senderId, request.receiverId);
+      
+      try {
+        await friendRepository.createFriendship(db, request.senderId, request.receiverId);
+      } catch (error) {
+        await friendRepository.updateRequestStatus(db, requestId, 'pending');
+        throw new ApiError(500, "Failed to create friendship. Process rolled back.");
+      }
       
       return { success: true, message: "Friend request accepted" };
     } finally {

--- a/api_server/src/service/friendService.ts
+++ b/api_server/src/service/friendService.ts
@@ -3,28 +3,33 @@ import { ApiError } from '../utils/apiError';
 import { createDbClient } from '../repository/dbClient';
 
 export const friendService = {
-  sendFriendRequest: async (senderId: string, receiverId: string) => {
+sendFriendRequest: async (senderId: string, receiverId: string) => {
     const { db, close } = createDbClient();
     try {
       if (senderId === receiverId) {
-        throw new ApiError(400, "Cannot send friend request to yourself");
+        throw new ApiError(422, "SOCIAL_SELF_REQUEST");
+      }
+
+      const receiverExists = await friendRepository.checkUserExists(db, receiverId);
+      if (!receiverExists) {
+        throw new ApiError(404, "NOT_FOUND");
       }
 
       const existingFriendship = await friendRepository.getFriendshipBetweenUsers(db, senderId, receiverId);
       if (existingFriendship) {
-        throw new ApiError(409, "Users are already friends");
+        throw new ApiError(409, "SOCIAL_ALREADY_FRIENDS");
       }
 
       const existingRequest = await friendRepository.getPendingRequestBetweenUsers(db, senderId, receiverId);
       if (existingRequest) {
-        throw new ApiError(409, "A pending friend request already exists between these users");
+        throw new ApiError(409, "SOCIAL_REQUEST_EXISTS");
       }
 
       try {
         return await friendRepository.createRequest(db, senderId, receiverId);
       } catch (error: any) {
         if (error.message && (error.message.includes('duplicate key') || error.message.includes('unique constraint'))) {
-          throw new ApiError(409, "A friend request already exists between these users");
+          throw new ApiError(409, "SOCIAL_REQUEST_EXISTS");
         }
         throw error;
       }

--- a/api_server/src/service/friendService.ts
+++ b/api_server/src/service/friendService.ts
@@ -1,17 +1,36 @@
 import { friendRepository } from '../repository/friendRepository';
 import { ApiError } from '../utils/apiError';
-import { createDbClient } from '../repository/dbClient'; /
+import { createDbClient } from '../repository/dbClient';
 
 export const friendService = {
   sendFriendRequest: async (senderId: string, receiverId: string) => {
-    const { db, close } = createDbClient(); 
+    const { db, close } = createDbClient();
     try {
       if (senderId === receiverId) {
         throw new ApiError(400, "Cannot send friend request to yourself");
       }
-      return await friendRepository.createRequest(db, senderId, receiverId);
+
+      const existingFriendship = await friendRepository.getFriendshipBetweenUsers(db, senderId, receiverId);
+      if (existingFriendship) {
+        throw new ApiError(409, "Users are already friends");
+      }
+
+      const existingRequest = await friendRepository.getPendingRequestBetweenUsers(db, senderId, receiverId);
+      if (existingRequest) {
+        throw new ApiError(409, "A pending friend request already exists between these users");
+      }
+
+      try {
+        return await friendRepository.createRequest(db, senderId, receiverId);
+      } catch (error: any) {
+        if (error.message && (error.message.includes('duplicate key') || error.message.includes('unique constraint'))) {
+          throw new ApiError(409, "A friend request already exists between these users");
+        }
+        throw error;
+      }
+
     } finally {
-      await close(); 
+      await close();
     }
   },
 

--- a/api_server/src/utils/apiError.ts
+++ b/api_server/src/utils/apiError.ts
@@ -1,0 +1,9 @@
+export class ApiError extends Error {
+  public statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.statusCode = statusCode;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}


### PR DESCRIPTION



### 概要
Issue: #22
フレンド機能に関する最低限のAPI実装およびデータベース（Drizzle ORM）との連携を行いました。
要件定義書 (`docs/api.md`) の仕様に基づき、重複チェックやエラーハンドリングなど、堅牢性を意識した実装を行っています。

### 実装内容
* **エンドポイントの作成**:
  * `POST /api/friends/requests` (申請送信)
  * `GET /api/friends/requests` (自分宛の申請一覧取得)
  * `POST /api/friends/requests/:id/accept` (承諾)
  * `POST /api/friends/requests/:id/reject` (拒否)
  * `GET /api/friends` (フレンドリスト取得)
  * `POST /api/friends/:id/remove` (フレンド解除)
* **データの整合性担保**:
  * `ApiError` カスタムクラスを導入し、仕様に沿った適切なHTTPステータス（`400`, `403`, `404`, `409`, `500`）を返すように統一しました。
  * **双方向フレンドの保存**: 仕様書通り、フレンド成立時に `friendships` テーブルへ双方向（A→B, B→A）のレコードを保存するように対応しました。
  * **ロールバック対応**: 申請の承諾時、フレンドレコードの作成に失敗した場合は申請ステータスを `pending` に戻す（擬似トランザクション）処理を追加しました。
  * **重複チェック**: すでにフレンドである場合や、お互いにすれ違いで申請を送ろうとした場合のエラー処理（`409 Conflict`）を実装しました。
* **DBコネクション管理**:
  * コネクションリークを防ぐため、Service層でリクエストごとに `db` インスタンスを生成し、`finally` で確実に `close()` する DI (依存性注入) パターンを採用しました。

### 今後の課題 
現状はAPIの基盤のみのため、以下の実装は別PR（またはフロントエンド連携時）に行う想定です。
1. **認証（JWT）との結合**:
   * 現在はテストのため `senderId` や `userId` を Body から直接受け取っていますが、最終的には認証ミドルウェアを通し、JWTトークンから自分の `userId` を取得・検証する形に修正する必要があります。
2. **Socket連携（オンラインステータス）**:
   * `GET /api/friends` で現在全員一律 `"offline"` を返している部分を、Socketサーバー（Redis等）のプレゼンス管理と同期させてリアルタイムな状態を返すように修正します。

---

###  動作確認

#### テスト用ユーザーの作成
テスト用のダミーユーザー（taro, hanako）を作成します。
```bash
curl -X POST http://localhost:4001/api/mock/analysis/scores \
-H "Content-Type: application/json" \
-d '{"player1Nickname": "taro","player2Nickname": "hanako","winner": "player1","player1Score": 3,"player2Score": 1}'
```
その後それぞれのAPIの実行
以下が実行結果（非常に見づらくてすみません🙇）
```shell
zsh@MacBook-Pro ~/42Tokyo/ft_transcendence feat/friends+ $ curl -X POST http://localhost:4001/api/mock/analysis/scores \
-H "Content-Type: application/json" \
-d '{"player1Nickname": "taro","player2Nickname": "hanako","winner": "player1","player1Score": 3,"player2Score": 1}'
{"ok":true,"created":{"roomId":"744bda78-b84b-4cd7-a23b-45048a6f0e7e","sessionId":"408673df-5937-4dff-a2a1-b597b1024fb7","matchRecordId":"b8119865-4f2b-479f-9e2e-598b4f5e0ded","player1":{"id":"b181c860-4fed-4f74-ab5f-8e63efa99eb3","nickname":"taro"},"player2":{"id":"24da51a0-6f3d-4aec-b070-6295742660f8","nickname":"hanako"},"winnerId":"b181c860-4fed-4f74-ab5f-8e63efa99eb3","submittedScore":{"player1":3,"player2":1}}}%

zsh@MacBook-Pro ~/42Tokyo/ft_transcendence feat/friends+ $ curl -X POST http://localhost:4001/api/friends/requests \
-H "Content-Type: application/json" \
-d '{
  "senderId": "b181c860-4fed-4f74-ab5f-8e63efa99eb3",
  "receiverId": "24da51a0-6f3d-4aec-b070-6295742660f8"
}'
{"id":"bfc42d3a-ea43-4831-92e2-e70ebc6af00a","senderId":"b181c860-4fed-4f74-ab5f-8e63efa99eb3","receiverId":"24da51a0-6f3d-4aec-b070-6295742660f8","status":"pending","createdAt":"2026-04-14T13:17:58.677Z","updatedAt":"2026-04-14T13:17:58.677Z"}%

zsh@MacBook-Pro ~/42Tokyo/ft_transcendence feat/friends+ $ curl -X GET "http://localhost:4001/api/friends/requests?userId=24da51a0-6f3d-4aec-b070-6295742660f8"
[{"id":"bfc42d3a-ea43-4831-92e2-e70ebc6af00a","senderId":"b181c860-4fed-4f74-ab5f-8e63efa99eb3","createdAt":"2026-04-14T13:17:58.677Z","senderNickname":"taro","senderAvatar":null}]%

zsh@MacBook-Pro ~/42Tokyo/ft_transcendence feat/friends+ $ curl -X POST http://localhost:4001/api/friends/requests/bfc42d3a-ea43-4831-92e2-e70ebc6af00a/accept
{"success":true,"message":"Friend request accepted"}%

zsh@MacBook-Pro ~/42Tokyo/ft_transcendence feat/friends+ $ curl -X GET "http://localhost:4001/api/friends?userId=b181c860-4fed-4f74-ab5f-8e63efa99eb3"
[{"userId":"24da51a0-6f3d-4aec-b070-6295742660f8","onlineStatus":"offline"}]%

zsh@MacBook-Pro ~/42Tokyo/ft_transcendence feat/friends+ $ curl -X POST http://localhost:4001/api/friends/24da51a0-6f3d-4aec-b070-6295742660f8/remove \
-H "Content-Type: application/json" \
-d '{
  "userId": "b181c860-4fed-4f74-ab5f-8e63efa99eb3"
}'
{"success":true,"message":"Friend removed"}%
 ```
