### PR TITLE
fix: skip saving match results for CPU games

### DIFF
--- a/socket_server/game/room-service.js
+++ b/socket_server/game/room-service.js
@@ -190,7 +190,7 @@ function createRoomService(io, presenceManager) {
             return Promise.resolve();
         }
 
-        if (room.solo === true && winnerId !== player1.userId) {
+        if (room.solo === true) {
             return Promise.resolve();
         }
 


### PR DESCRIPTION
  ## Summary
  - CPU戦の戦績を一切保存しないように変更
  - 以前は CPU に勝った場合のみ保存していたが、チームの方針で CPU戦は勝敗問わず保存しないことに決定

  Closes #50"