### PR TITLE
feat: look up friends by nickname instead of UUID (#53)

### DIFF
--- a/api_server/src/repository/userRepository.ts
+++ b/api_server/src/repository/userRepository.ts
@@ -27,6 +27,14 @@ export const userRepository = {
         return result[0] ?? null;
     },
 
+    findByNickname: async (db: AppDb, nickname: string) => {
+        const result = await db
+            .select()
+            .from(users)
+            .where(eq(users.nickname, nickname));
+        return result[0] ?? null;
+    },
+
     emailExists: async (db: AppDb, email: string): Promise<boolean> => {
         const result = await db
             .select({ id: users.id })

--- a/api_server/src/routes/friends/index.ts
+++ b/api_server/src/routes/friends/index.ts
@@ -13,12 +13,14 @@ const sendRequestSchema = z
     .object({
         receiver_id: z.string().optional(),
         receiverId: z.string().optional(),
+        nickname: z.string().optional(),
     })
-    .refine((data) => data.receiver_id || data.receiverId, {
-        message: 'receiver_id is required',
+    .refine((data) => data.receiver_id || data.receiverId || data.nickname, {
+        message: 'receiver_id or nickname is required',
     })
     .transform((data) => ({
-        receiverId: (data.receiver_id ?? data.receiverId) as string,
+        receiverId: (data.receiver_id ?? data.receiverId) as string | undefined,
+        nickname: data.nickname,
     }));
 
 // --- Routes ---
@@ -43,10 +45,11 @@ friendsRoute.post(
     zValidator('json', sendRequestSchema),
     async (c) => {
         const userId = c.get('userId');
-        const { receiverId } = c.req.valid('json');
+        const { receiverId, nickname } = c.req.valid('json');
         const result = await friendService.sendFriendRequest(
             userId,
             receiverId,
+            nickname,
         );
         return c.json(result, 201);
     },

--- a/api_server/src/service/friendService.ts
+++ b/api_server/src/service/friendService.ts
@@ -1,18 +1,37 @@
 import { friendRepository } from '../repository/friendRepository';
+import { userRepository } from '../repository/userRepository';
 import { ApiError } from '../utils/apiError';
 import { createDbClient } from '../repository/dbClient';
 
 export const friendService = {
-    sendFriendRequest: async (senderId: string, receiverId: string) => {
+    sendFriendRequest: async (
+        senderId: string,
+        receiverId?: string,
+        nickname?: string,
+    ) => {
         const { db, close } = createDbClient();
         try {
-            if (senderId === receiverId) {
+            let resolvedReceiverId = receiverId;
+
+            if (!resolvedReceiverId && nickname) {
+                const user = await userRepository.findByNickname(db, nickname);
+                if (!user) {
+                    throw new ApiError(404, 'USER_NOT_FOUND');
+                }
+                resolvedReceiverId = user.id;
+            }
+
+            if (!resolvedReceiverId) {
+                throw new ApiError(422, 'receiver_id or nickname is required');
+            }
+
+            if (senderId === resolvedReceiverId) {
                 throw new ApiError(422, 'SOCIAL_SELF_REQUEST');
             }
 
             const receiverExists = await friendRepository.checkUserExists(
                 db,
-                receiverId,
+                resolvedReceiverId,
             );
             if (!receiverExists) {
                 throw new ApiError(404, 'NOT_FOUND');
@@ -22,7 +41,7 @@ export const friendService = {
                 await friendRepository.getFriendshipBetweenUsers(
                     db,
                     senderId,
-                    receiverId,
+                    resolvedReceiverId,
                 );
             if (existingFriendship) {
                 throw new ApiError(409, 'SOCIAL_ALREADY_FRIENDS');
@@ -32,7 +51,7 @@ export const friendService = {
                 await friendRepository.getPendingRequestBetweenUsers(
                     db,
                     senderId,
-                    receiverId,
+                    resolvedReceiverId,
                 );
             if (existingRequest) {
                 throw new ApiError(409, 'SOCIAL_REQUEST_EXISTS');
@@ -41,7 +60,7 @@ export const friendService = {
             return await friendRepository.createRequest(
                 db,
                 senderId,
-                receiverId,
+                resolvedReceiverId,
             );
         } finally {
             await close();
@@ -144,10 +163,18 @@ export const friendService = {
             );
             const uniqueFriendIds = Array.from(new Set(rawFriendIds));
 
-            return uniqueFriendIds.map((id) => ({
-                userId: id,
-                onlineStatus: 'offline',
-            }));
+            const friendsWithNicknames = await Promise.all(
+                uniqueFriendIds.map(async (id) => {
+                    const user = await userRepository.findById(db, id);
+                    return {
+                        userId: id,
+                        nickname: user?.nickname ?? null,
+                        onlineStatus: 'offline',
+                    };
+                }),
+            );
+
+            return friendsWithNicknames;
         } finally {
             await close();
         }

--- a/frontend/app/components/InviteToast.tsx
+++ b/frontend/app/components/InviteToast.tsx
@@ -6,6 +6,7 @@ import { usePresenceSocket } from './PresenceProvider';
 
 type PendingInvite = {
     fromUserId: string;
+    fromNickname?: string;
     roomId: string;
     password: string;
 };
@@ -45,7 +46,8 @@ export function InviteToast() {
             <p className="font-medium">
                 Match invite from{' '}
                 <span className="text-orange-400">
-                    {invite.fromUserId.substring(0, 8)}…
+                    {invite.fromNickname ||
+                        invite.fromUserId.substring(0, 8) + '…'}
                 </span>
             </p>
             <div className="flex gap-2">

--- a/frontend/app/game/multiplayer/page.tsx
+++ b/frontend/app/game/multiplayer/page.tsx
@@ -17,6 +17,7 @@ import { CustomizationPanel } from '../components/CustomizationPanel';
 import { FpsCounter } from '../utils/FpsCounter';
 import { useCustomization } from '../hooks/useCustomization';
 import { usePresenceSocket } from '@/app/components/PresenceProvider';
+import { apiGetMe } from '@/lib/api';
 
 export default function GamePage() {
     const [name, setName] = useState('Player');
@@ -27,7 +28,16 @@ export default function GamePage() {
     const autoJoinFiredRef = useRef(false);
 
     // Invite-a-friend state
+    const [myNickname, setMyNickname] = useState<string | undefined>();
     const socket = usePresenceSocket();
+
+    useEffect(() => {
+        apiGetMe()
+            .then(({ user }) => {
+                if (user?.nickname) setMyNickname(user.nickname);
+            })
+            .catch(() => {});
+    }, []);
     const {
         socketRef,
         connected,
@@ -89,8 +99,9 @@ export default function GamePage() {
             toUserId: challengeTarget,
             roomId: joinedRoomId,
             password: challengePw,
+            fromNickname: myNickname,
         });
-    }, [joinedRoomId, socket, searchParams]);
+    }, [joinedRoomId, socket, searchParams, myNickname]);
 
     const handleCreateRoom = () => {
         createRoom({ name, password });

--- a/frontend/app/lobby/components/FriendsSidebar.tsx
+++ b/frontend/app/lobby/components/FriendsSidebar.tsx
@@ -379,11 +379,16 @@ export function FriendsSidebar() {
                                         <div className="flex flex-col truncate pr-2">
                                             <span
                                                 className="text-sm text-neutral-100 truncate"
-                                                title={friend.nickname || friend.userId}
+                                                title={
+                                                    friend.nickname ||
+                                                    friend.userId
+                                                }
                                             >
                                                 {friend.nickname ||
-                                                    friend.userId.substring(0, 8) +
-                                                        '…'}
+                                                    friend.userId.substring(
+                                                        0,
+                                                        8,
+                                                    ) + '…'}
                                             </span>
                                             <span className="flex items-center gap-1.5 text-[10px] text-neutral-400 uppercase tracking-wider">
                                                 <span

--- a/frontend/app/lobby/components/FriendsSidebar.tsx
+++ b/frontend/app/lobby/components/FriendsSidebar.tsx
@@ -205,7 +205,9 @@ export function FriendsSidebar() {
                                             className="text-sm text-neutral-100 truncate"
                                             title={friend.userId}
                                         >
-                                            {friend.nickname || friend.userId.substring(0, 8) + '...'}
+                                            {friend.nickname ||
+                                                friend.userId.substring(0, 8) +
+                                                    '...'}
                                         </span>
                                         <span className="flex items-center gap-1.5 text-[10px] text-neutral-400 uppercase tracking-wider">
                                             <span

--- a/frontend/app/lobby/components/FriendsSidebar.tsx
+++ b/frontend/app/lobby/components/FriendsSidebar.tsx
@@ -375,24 +375,26 @@ export function FriendsSidebar() {
                                     key={friend.userId}
                                     className="group rounded-lg border border-neutral-800 bg-neutral-900/80 transition hover:border-neutral-700"
                                 >
-                                <div className="flex items-center justify-between px-3 py-2">
-                                    <div className="flex flex-col truncate pr-2">
-                                        <span
-                                            className="text-sm text-neutral-100 truncate"
-                                            title={friend.userId}
-                                        >
-                                            {friend.nickname ||
-                                                friend.userId.substring(0, 8) +
-                                                    '...'}
-                                        </span>
-                                        <span className="flex items-center gap-1.5 text-[10px] text-neutral-400 uppercase tracking-wider">
-                                            <span className="flex items-center gap-1.5 text-[10px] text-neutral-400 uppercase tracking-wider">
-                                                <span
-                                                    className={`h-1.5 w-1.5 rounded-full ${statusColor}`}
-                                                />
-                                                {status.replace('_', ' ')}
+                                    <div className="flex items-center justify-between px-3 py-2">
+                                        <div className="flex flex-col truncate pr-2">
+                                            <span
+                                                className="text-sm text-neutral-100 truncate"
+                                                title={friend.userId}
+                                            >
+                                                {friend.nickname ||
+                                                    friend.userId.substring(
+                                                        0,
+                                                        8,
+                                                    ) + '...'}
                                             </span>
-                                        </span>
+                                            <span className="flex items-center gap-1.5 text-[10px] text-neutral-400 uppercase tracking-wider">
+                                                <span className="flex items-center gap-1.5 text-[10px] text-neutral-400 uppercase tracking-wider">
+                                                    <span
+                                                        className={`h-1.5 w-1.5 rounded-full ${statusColor}`}
+                                                    />
+                                                    {status.replace('_', ' ')}
+                                                </span>
+                                            </span>
                                         </div>
                                         <div className="flex items-center gap-1.5">
                                             {/* Challenge button */}

--- a/frontend/app/lobby/components/FriendsSidebar.tsx
+++ b/frontend/app/lobby/components/FriendsSidebar.tsx
@@ -18,12 +18,14 @@ import { useDmChat, type DmMessage } from '../hooks/useDmChat';
 
 function FloatingChatWindow({
     userId,
+    displayName,
     thread,
     isOfflineWarning,
     onClose,
     onSend,
 }: {
     userId: string;
+    displayName: string;
     thread: DmMessage[];
     isOfflineWarning: boolean;
     onClose: () => void;
@@ -48,9 +50,9 @@ function FloatingChatWindow({
             <div className="flex items-center justify-between border-b border-neutral-700/80 bg-neutral-900/90 px-3 py-2">
                 <span
                     className="truncate text-xs font-semibold text-neutral-200"
-                    title={userId}
+                    title={displayName}
                 >
-                    {userId.substring(0, 10)}…
+                    {displayName}
                 </span>
                 <button
                     type="button"
@@ -487,20 +489,26 @@ export function FriendsSidebar() {
             {/* --- Floating chat windows (Facebook-style) --- */}
             {openChatIds.length > 0 && (
                 <div className="pointer-events-none fixed bottom-0 right-0 z-50 flex max-w-full flex-row-reverse items-end gap-1 overflow-hidden">
-                    {openChatIds.map((userId) => (
-                        <div
-                            key={userId}
-                            className="pointer-events-auto min-w-20 max-w-64 flex-1"
-                        >
-                            <FloatingChatWindow
-                                userId={userId}
-                                thread={threads[userId] ?? []}
-                                isOfflineWarning={offlineUserId === userId}
-                                onClose={() => closeChat(userId)}
-                                onSend={(text) => sendDm(userId, text)}
-                            />
-                        </div>
-                    ))}
+                    {openChatIds.map((userId) => {
+                        const friend = friends.find((f) => f.userId === userId);
+                        const name =
+                            friend?.nickname || userId.substring(0, 8) + '…';
+                        return (
+                            <div
+                                key={userId}
+                                className="pointer-events-auto min-w-20 max-w-64 flex-1"
+                            >
+                                <FloatingChatWindow
+                                    userId={userId}
+                                    displayName={name}
+                                    thread={threads[userId] ?? []}
+                                    isOfflineWarning={offlineUserId === userId}
+                                    onClose={() => closeChat(userId)}
+                                    onSend={(text) => sendDm(userId, text)}
+                                />
+                            </div>
+                        );
+                    })}
                 </div>
             )}
         </>

--- a/frontend/app/lobby/components/FriendsSidebar.tsx
+++ b/frontend/app/lobby/components/FriendsSidebar.tsx
@@ -19,7 +19,7 @@ export function FriendsSidebar() {
     const [currentUserId, setCurrentUserId] = useState<string | null>(null);
     const [friends, setFriends] = useState<any[]>([]);
     const [requests, setRequests] = useState<any[]>([]);
-    const [targetId, setTargetId] = useState('');
+    const [targetNickname, setTargetNickname] = useState('');
     const [message, setMessage] = useState('');
 
     // リアルタイムプレゼンス
@@ -59,11 +59,11 @@ export function FriendsSidebar() {
 
     // アクションハンドラ
     const handleSendRequest = async () => {
-        if (!currentUserId || !targetId) return;
+        if (!currentUserId || !targetNickname) return;
         try {
-            await apiSendFriendRequest(targetId);
+            await apiSendFriendRequest(targetNickname);
             setMessage('申請を送信しました');
-            setTargetId('');
+            setTargetNickname('');
         } catch (error: any) {
             setMessage(error.message || 'エラーが発生しました');
         }
@@ -122,9 +122,9 @@ export function FriendsSidebar() {
                 <div className="space-y-2">
                     <input
                         type="text"
-                        value={targetId}
-                        onChange={(e) => setTargetId(e.target.value)}
-                        placeholder="Add friend by ID..."
+                        value={targetNickname}
+                        onChange={(e) => setTargetNickname(e.target.value)}
+                        placeholder="Add friend by nickname..."
                         className="w-full rounded-lg border border-neutral-700 bg-neutral-900/80 px-3 py-1.5 text-xs text-neutral-200 outline-none focus:border-emerald-500 transition"
                     />
                     <button
@@ -205,7 +205,7 @@ export function FriendsSidebar() {
                                             className="text-sm text-neutral-100 truncate"
                                             title={friend.userId}
                                         >
-                                            {friend.userId.substring(0, 8)}...
+                                            {friend.nickname || friend.userId.substring(0, 8) + '...'}
                                         </span>
                                         <span className="flex items-center gap-1.5 text-[10px] text-neutral-400 uppercase tracking-wider">
                                             <span

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -171,11 +171,11 @@ export async function apiGetFriendRequests(): Promise<any[]> {
     return apiFetch<any[]>('/friends/requests');
 }
 
-// フレンド申請を送信 (senderId は JWT から取得 — 呼び出し元は receiverId のみ渡す)
-export async function apiSendFriendRequest(receiverId: string) {
+// フレンド申請を送信 (senderId は JWT から取得 — ニックネームで検索)
+export async function apiSendFriendRequest(nickname: string) {
     return apiFetch('/friends/requests', {
         method: 'POST',
-        body: JSON.stringify({ receiver_id: receiverId }),
+        body: JSON.stringify({ nickname }),
     });
 }
 

--- a/socket_server/socket-handlers.js
+++ b/socket_server/socket-handlers.js
@@ -298,29 +298,40 @@ function registerSocketHandlers(io, roomService) {
         });
 
         // ── Room invites ───────────────────────────────────────────────────────
-        socket.on('sendRoomInvite', ({ toUserId, roomId, password, fromNickname }) => {
-            if (
-                typeof toUserId !== 'string' ||
-                typeof roomId !== 'string' ||
-                typeof password !== 'string'
-            ) {
-                return;
-            }
+        socket.on(
+            'sendRoomInvite',
+            ({ toUserId, roomId, password, fromNickname }) => {
+                if (
+                    typeof toUserId !== 'string' ||
+                    typeof roomId !== 'string' ||
+                    typeof password !== 'string'
+                ) {
+                    return;
+                }
 
-            const targetRoom = io.sockets.adapter.rooms.get(`dm_${toUserId}`);
-            if (!targetRoom || targetRoom.size === 0) {
-                socket.emit('dmFailed', { toUserId, reason: 'user_offline' });
-                return;
-            }
+                const targetRoom = io.sockets.adapter.rooms.get(
+                    `dm_${toUserId}`,
+                );
+                if (!targetRoom || targetRoom.size === 0) {
+                    socket.emit('dmFailed', {
+                        toUserId,
+                        reason: 'user_offline',
+                    });
+                    return;
+                }
 
-            io.to(`dm_${toUserId}`).emit('receiveRoomInvite', {
-                fromUserId: userId,
-                fromNickname: typeof fromNickname === 'string' ? fromNickname : undefined,
-                roomId,
-                password,
-                timestamp: Date.now(),
-            });
-        });
+                io.to(`dm_${toUserId}`).emit('receiveRoomInvite', {
+                    fromUserId: userId,
+                    fromNickname:
+                        typeof fromNickname === 'string'
+                            ? fromNickname
+                            : undefined,
+                    roomId,
+                    password,
+                    timestamp: Date.now(),
+                });
+            },
+        );
 
         socket.on('disconnect', () => {
             // 切断されたら「オフライン」として登録し、全員に通知

--- a/socket_server/socket-handlers.js
+++ b/socket_server/socket-handlers.js
@@ -298,7 +298,7 @@ function registerSocketHandlers(io, roomService) {
         });
 
         // ── Room invites ───────────────────────────────────────────────────────
-        socket.on('sendRoomInvite', ({ toUserId, roomId, password }) => {
+        socket.on('sendRoomInvite', ({ toUserId, roomId, password, fromNickname }) => {
             if (
                 typeof toUserId !== 'string' ||
                 typeof roomId !== 'string' ||
@@ -315,6 +315,7 @@ function registerSocketHandlers(io, roomService) {
 
             io.to(`dm_${toUserId}`).emit('receiveRoomInvite', {
                 fromUserId: userId,
+                fromNickname: typeof fromNickname === 'string' ? fromNickname : undefined,
                 roomId,
                 password,
                 timestamp: Date.now(),


### PR DESCRIPTION
  Title:
  feat: look up friends by nickname instead of UUID (#53)

  Body:
  ## Summary
  - フレンド申請をUUIDではなくニックネームで送れるように変更
  - フレンド一覧にニックネームを表示するように変更

  ## Changes
  - `userRepository.findByNickname()` を追加
  - `friendService.sendFriendRequest()` で nickname → userId
  の解決ロジックを追加
  - フロントの入力欄を「Add friend by nickname...」に変更
  - フレンド一覧の表示をニックネームに変更

  Closes #53